### PR TITLE
Using default transaction option - removing syncFinalize as k23si Pus…

### DIFF
--- a/src/k2/connector/yb/pggate/k2_adapter.cc
+++ b/src/k2/connector/yb/pggate/k2_adapter.cc
@@ -493,9 +493,8 @@ std::future<K23SITxn> K2Adapter::beginTransaction() {
     k2::K2TxnOptions options{};
     // use default values for now
     // TODO: read from configuration/env files
-    options.deadline = k2::Duration(default_client_read_write_timeout_ms * 1ms);
-    options.priority = k2::dto::TxnPriority::Medium;
-    options.syncFinalize = true;
+    //options.deadline = k2::Duration(default_client_read_write_timeout_ms * 1ms);
+    //options.priority = k2::dto::TxnPriority::Medium;
     return k23si_->beginTxn(options);
 }
 


### PR DESCRIPTION
…h now handles committed/aborted incumbent properly.