### PR TITLE
add logs to track ybctid_bind_ flag and disable ybctid_bind_ for INSERT

### DIFF
--- a/src/k2/connector/yb/pggate/pg_dml.cc
+++ b/src/k2/connector/yb/pggate/pg_dml.cc
@@ -181,6 +181,7 @@ Status PgDml::BindColumn(int attr_num, PgExpr *attr_value) {
     // YBC logic uses a virtual column ybctid as a row id in a string format
     // we need to follow the logic unless we change the logic inside PG
     CHECK(attr_value->is_constant()) << "Column ybctid must be bound to constant";
+    LOG(INFO) << "kYBTupleId was bound and ybctid_bind_ is set as true";
     ybctid_bind_ = true;
   }
 

--- a/src/k2/connector/yb/pggate/pg_dml_read.cc
+++ b/src/k2/connector/yb/pggate/pg_dml_read.cc
@@ -161,6 +161,7 @@ Status PgDmlRead::BindColumnCondEq(int attr_num, PgExpr *attr_value) {
 
   if (attr_num == static_cast<int>(PgSystemAttrNum::kYBTupleId)) {
     CHECK(attr_value->is_constant()) << "Column ybctid must be bound to constant";
+    LOG(INFO) << "kYBTupleId was bound and ybctid_bind_ is set as true";
     ybctid_bind_ = true;
   }
 
@@ -275,6 +276,7 @@ Status PgDmlRead::BindColumnCondIn(int attr_num, int n_attr_values, PgExpr **att
 
       if (attr_num == static_cast<int>(PgSystemAttrNum::kYBTupleId)) {
         CHECK(attr_values[i]->is_constant()) << "Column ybctid must be bound to constant";
+        LOG(INFO) << "kYBTupleId was bound and ybctid_bind_ is set as true";
         ybctid_bind_ = true;
       }
     }
@@ -305,6 +307,7 @@ Status PgDmlRead::BindColumnCondIn(int attr_num, int n_attr_values, PgExpr **att
 
       if (attr_num == static_cast<int>(PgSystemAttrNum::kYBTupleId)) {
         CHECK(attr_values[i]->is_constant()) << "Column ybctid must be bound to constant";
+        LOG(INFO) << "kYBTupleId was bound and ybctid_bind_ is set as true";
         ybctid_bind_ = true;
       }
     }

--- a/src/k2/connector/yb/pggate/pg_dml_write.cc
+++ b/src/k2/connector/yb/pggate/pg_dml_write.cc
@@ -113,7 +113,9 @@ Status PgDmlWrite::DeleteEmptyPrimaryBinds() {
   bool missing_primary_key = false;
 
   // Either ybctid or primary key must be present.
-  if (!ybctid_bind_) {
+  // always use regular binding for INSERT
+  if (stmt_op() == StmtOp::STMT_INSERT || !ybctid_bind_) {
+    LOG(INFO) << "Checking missing primary keys for regular key binding";
     // Remove empty binds from key list.
     auto key_iter = write_req_->key_column_values.begin();
     while (key_iter != write_req_->key_column_values.end()) {
@@ -125,6 +127,7 @@ Status PgDmlWrite::DeleteEmptyPrimaryBinds() {
       }
     }
   } else {
+    LOG(INFO) << "Clearing key column values for ybctid binding";
     write_req_->key_column_values.clear();
   }
 


### PR DESCRIPTION
SKV client does not support ybctid for INSERT operation. Change to use regular binding instead of ybctid_bind for INSERT.