### PR TITLE
set the read op request limit as a global limit instead of a page limit

### DIFF
--- a/pgtest/pg_initDB.sh
+++ b/pgtest/pg_initDB.sh
@@ -22,6 +22,7 @@ export EPS="tcp+k2rpc://0.0.0.0:10000"
 export PERSISTENCE=tcp+k2rpc://0.0.0.0:12001
 export GLOG_logtostderr=1 # log all to stderr
 export GLOG_v=5 #
+export GLOG_log_dir=/tmp
 
 rm -rf pgroot/data
 mkdir -p pgroot/data

--- a/src/k2/connector/yb/pggate/k2_adapter.cc
+++ b/src/k2/connector/yb/pggate/k2_adapter.cc
@@ -277,11 +277,11 @@ std::future<Status> K2Adapter::handleReadOp(std::shared_ptr<K23SITxn> k23SITxn,
                 prom->set_value(std::move(startStatus));
                 return;
             }
-        }
 
-        // this is a per-page limit.
-        if (request->limit > 0) {
-            scan->setLimit(request->limit);
+            // this is a total limit.
+            if (request->limit > 0) {
+                scan->setLimit(request->limit);
+            }
         }
 
         k2::QueryResult scan_result = k23SITxn->scanRead(scan).get();

--- a/src/k2/connector/yb/pggate/pg_gate_defaults.h
+++ b/src/k2/connector/yb/pggate/pg_gate_defaults.h
@@ -36,14 +36,14 @@ namespace gate {
     constexpr int32_t default_output_buffer_size = 262144;
 
     // should disable index backfill or not
-    static bool const default_disable_index_backfill = true; 
+    static bool const default_disable_index_backfill = true;
 
-    static const uint64_t default_ysql_prefetch_limit = 4;
+    static const uint64_t default_ysql_prefetch_limit = 1000;
 
     static const uint64_t default_ysql_request_limit = 1;
 
     static const uint64_t default_ysql_select_parallelism = 1;
-    
+
     static const double default_ysql_backward_prefetch_scale_factor = 0.25;
 
     static const int default_session_max_batch_size = 1;

--- a/src/k2/connector/yb/pggate/pg_op.cc
+++ b/src/k2/connector/yb/pggate/pg_op.cc
@@ -489,7 +489,7 @@ void PgReadOp::ExecuteInit(const PgExecParameters *exec_params) {
     PgOp::ExecuteInit(exec_params);
 
     template_op_->set_return_paging_state(true);
-    SetRequestPrefetchLimit();
+    SetRequestTotalLimit();
     SetRowMark();
     SetReadTime();
 }
@@ -587,6 +587,13 @@ void PgReadOp::SetRequestPrefetchLimit() {
         limit_count = predicted_limit;
         suppress_next_result_prefetching_ = false;
     }
+    req->limit = limit_count;
+}
+
+void PgReadOp::SetRequestTotalLimit() {
+    std::shared_ptr<SqlOpReadRequest> req = template_op_->request();
+    // Use statement LIMIT(count + offset) if it is smaller than the predicted limit.
+    int64_t limit_count = exec_params_.limit_count + exec_params_.limit_offset;
     req->limit = limit_count;
 }
 

--- a/src/k2/connector/yb/pggate/pg_op.h
+++ b/src/k2/connector/yb/pggate/pg_op.h
@@ -288,6 +288,9 @@ private:
     // Analyze options and pick the appropriate prefetch limit.
     void SetRequestPrefetchLimit();
 
+    // set the global limit on the query
+    void SetRequestTotalLimit();
+
     // Set the row_mark_type field of our read request based on our exec control parameter.
     void SetRowMark();
 


### PR DESCRIPTION
set the read op request limit as a global limit instead of a page limit