### PR TITLE
change index SKV schema generation logic to use IndexColumn directly and honor the keys from PG

### DIFF
--- a/src/k2/connector/yb/pggate/catalog/table_info_handler.cc
+++ b/src/k2/connector/yb/pggate/catalog/table_info_handler.cc
@@ -331,7 +331,7 @@ CreateUpdateSKVSchemaResult TableInfoHandler::CreateOrUpdateTableSKVSchema(std::
 CreateUpdateSKVSchemaResult TableInfoHandler::CreateOrUpdateIndexSKVSchema(std::shared_ptr<SessionTransactionContext> context, std::string collection_name,
         std::shared_ptr<TableInfo> table, const IndexInfo& index_info) {
     CreateUpdateSKVSchemaResult response;
-    std::shared_ptr<k2::dto::Schema> index_schema = DeriveIndexSchema(index_info, table->schema());
+    std::shared_ptr<k2::dto::Schema> index_schema = DeriveIndexSchema(index_info);
     response.status = CreateSKVSchema(collection_name, index_schema);
     return response;
 }
@@ -596,12 +596,12 @@ std::vector<std::shared_ptr<k2::dto::Schema>> TableInfoHandler::DeriveIndexSchem
     std::vector<std::shared_ptr<k2::dto::Schema>> response;
     const IndexMap& index_map = table->secondary_indexes();
     for (const auto& pair : index_map) {
-        response.push_back(DeriveIndexSchema(pair.second, table->schema()));
+        response.push_back(DeriveIndexSchema(pair.second));
     }
     return response;
 }
 
-std::shared_ptr<k2::dto::Schema> TableInfoHandler::DeriveIndexSchema(const IndexInfo& index_info, const Schema& base_tablecolumn_schema) {
+std::shared_ptr<k2::dto::Schema> TableInfoHandler::DeriveIndexSchema(const IndexInfo& index_info) {
     std::shared_ptr<k2::dto::Schema> schema = std::make_shared<k2::dto::Schema>();
     schema->name = index_info.table_id();
     schema->version = index_info.version();

--- a/src/k2/connector/yb/pggate/catalog/table_info_handler.h
+++ b/src/k2/connector/yb/pggate/catalog/table_info_handler.h
@@ -222,7 +222,7 @@ class TableInfoHandler : public BaseHandler {
 
     std::vector<std::shared_ptr<k2::dto::Schema>> DeriveIndexSchemas(std::shared_ptr<TableInfo> table);
 
-    std::shared_ptr<k2::dto::Schema> DeriveIndexSchema(const IndexInfo& index_info, const Schema& base_tablecolumn_schema);
+    std::shared_ptr<k2::dto::Schema> DeriveIndexSchema(const IndexInfo& index_info);
 
     k2::dto::SKVRecord DeriveTableHeadRecord(std::string collection_name, std::shared_ptr<TableInfo> table);
 


### PR DESCRIPTION
1) Removed the logic to get the column fields from the base table or derive them, but to use IndexColumn fields directly since we have persisted all the fields in IndexColumn
2) Updated the partition keys to honor the primary keys passed from PG instead of using all fields as the partition keys.