### PR TITLE
echo query string in PG and update k2 adapter logs

### DIFF
--- a/src/k2/connector/yb/pggate/k2_adapter.cc
+++ b/src/k2/connector/yb/pggate/k2_adapter.cc
@@ -518,10 +518,10 @@ std::future<Status> K2Adapter::Exec(std::shared_ptr<K23SITxn> k23SITxn, std::sha
     op->allocateResponse();
     switch (op->type()) {
         case PgOpTemplate::WRITE:
-            K2LOG_I(log::pg, "Executing writing operation");
+            K2LOG_I(log::pg, "Executing writing operation for table {}", std::static_pointer_cast<PgWriteOpTemplate>(op)->request()->table_id);
             return handleWriteOp(k23SITxn, std::static_pointer_cast<PgWriteOpTemplate>(op));
         case PgOpTemplate::READ:
-            K2LOG_I(log::pg, "Executing reading operation");
+            K2LOG_I(log::pg, "Executing reading operation for table {}", std::static_pointer_cast<PgReadOpTemplate>(op)->request()->table_id);
             return handleReadOp(k23SITxn, std::static_pointer_cast<PgReadOpTemplate>(op));
         default:
           throw new std::logic_error("Unsupported op template type");

--- a/src/k2/postgres/src/bin/initdb/initdb.c
+++ b/src/k2/postgres/src/bin/initdb/initdb.c
@@ -196,7 +196,7 @@ static char *authwarning = NULL;
  * (no quoting to worry about).
  */
 static const char *boot_options = "-F";
-static const char *backend_options = "--single -F -O -j -c search_path=pg_catalog -c exit_on_error=true";
+static const char *backend_options = "--single -F -E -O -j -c search_path=pg_catalog -c exit_on_error=true";
 
 static const char *const subdirs[] = {
 	"global",


### PR DESCRIPTION
After the changes, we can see the query string that PG is executing:

[0000:03:10:50.877.470]-k2_pg-(k2::pggate:139729660611776) [INFO] [/build/src/k2/connector/yb/pggate/k2_adapter.cc:521 @Exec] Executing writing operation for table 00000001000030008000000000000d42
backend> statement: INSERT INTO pg_init_privs   (objoid, classoid, objsubid, initprivs, privtype)    SELECT        pg_class.oid,        (SELECT oid FROM pg_class WHERE relname = 'pg_class'),        pg_attribute.attnum,        pg_attribute.attacl,        'i'    FROM        pg_class        JOIN pg_attribute ON (pg_class.oid = pg_attribute.attrelid)    WHERE        pg_attribute.attacl IS NOT NULL        AND pg_class.relkind IN ('r', 'v', 'm', 'S');

[0000:03:10:50.886.056]-k2_pg-(k2::pggate:139729660611776) [INFO] [/build/src/k2/connector/yb/pggate/k2_adapter.cc:524 @Exec] Executing reading operation for table 00000001000030008000000000000a5e
