### PR TITLE
map decimal to k2 string instead of k2 decimal64

### DIFF
--- a/src/k2/connector/yb/pggate/catalog/table_info_handler.cc
+++ b/src/k2/connector/yb/pggate/catalog/table_info_handler.cc
@@ -1047,47 +1047,12 @@ k2::dto::FieldType TableInfoHandler::ToK2Type(DataType type) {
             field_type = k2::dto::FieldType::INT64T;
         } break;
         case DataType::DECIMAL: {
-            field_type = k2::dto::FieldType::DECIMAL64;
+            field_type = k2::dto::FieldType::STRING;
         } break;
         default:
             throw std::invalid_argument("Unsupported type " + type);
     }
     return field_type;
-}
-
-DataType TableInfoHandler::ToSqlType(k2::dto::FieldType type) {
-    // utility method, not used yet
-    DataType sql_type = DataType::NOT_SUPPORTED;
-    switch (type) {
-        case k2::dto::FieldType::INT16T: {
-            sql_type = DataType::INT16;
-        } break;
-        case k2::dto::FieldType::INT32T: {
-            sql_type = DataType::INT32;
-        } break;
-        case k2::dto::FieldType::INT64T: {
-            sql_type = DataType::INT64;
-        } break;
-        case k2::dto::FieldType::STRING: {
-            sql_type = DataType::STRING;
-        } break;
-        case k2::dto::FieldType::BOOL: {
-            sql_type = DataType::BOOL;
-        } break;
-        case k2::dto::FieldType::FLOAT: {
-            sql_type = DataType::FLOAT;
-        } break;
-        case k2::dto::FieldType::DOUBLE: {
-            sql_type = DataType::DOUBLE;
-        } break;
-        case k2::dto::FieldType::DECIMAL64: {
-            sql_type = DataType::DECIMAL;
-        } break;
-        default: {
-            throw std::invalid_argument(fmt::format("unsupported type: {}", type));
-        }
-    }
-    return sql_type;
 }
 
 k2::dto::SKVRecord TableInfoHandler::FetchTableHeadSKVRecord(std::shared_ptr<SessionTransactionContext> context, const std::string& collection_name, const std::string& table_id) {


### PR DESCRIPTION
as title

20:23:51,656 (DBWorkload.java:559) INFO  - Loading data into TPCC database with 1 threads...
20:23:55,279 (TPCCLoader.java:214) ERROR - Failed to load data for TPC-C
java.sql.BatchUpdateException: Batch entry 0 INSERT INTO ITEM VALUES (1, 'sxvnjhpdqdxvcrast', 84.7, 'ybcwvmgnykrxvzxkgxtspsjdgyl', 479) was aborted: An I/O error occurred while sending to the backend.  Call getNextException to see other errors in the batch.

2021-02-02 04:15:07.818 UTC [2507] STATEMENT:  INSERT INTO ITEM VALUES ($1, $2, $3, $4, $5)
2021-02-02 04:15:07.818 UTC [2507] LOG:  execute S_2: INSERT INTO ITEM VALUES ($1, $2, $3, $4, $5)
2021-02-02 04:15:07.818 UTC [2507] DETAIL:  parameters: $1 = '1', $2 = 'sxvnjhpdqdxvcra', $3 = '97.340000000000
0034', $4 = 'tvybcwvmgnykrxvzxkgxtspsj', $5 = '7063'
terminate called after throwing an instance of 'k2::dto::TypeMismatchException'
  what():  Schema not followed in record serialization

[12:26 PM] Justin Ryan Funston
    [0106:22:34:12.979.665]-k2_pg-(k2::pg_catalog:140335955000640) [DEBUG] [/build/src/k2/connector/yb/pggate/catal
og/base_handler.cc:45 @CreateSKVSchema] Created SKV Schema for 00000000000030008000000000004000 in ns 000030a80
00030008000000000000000 as: {​​​​​​​name=00000000000030008000000000004000, version=0, fields={​​​​​​​{​​​​​​​type=STRING, name=Table
Id, descending=false, nullLast=false}​​​​​​​, {​​​​​​​type=STRING, name=IndexId, descending=false, nullLast=false}​​​​​​​, {​​​​​​​type=INT
64T, name=i_id, descending=false, nullLast=false}​​​​​​​, {​​​​​​​type=STRING, name=i_name, descending=false, nullLast=false}​​​​​​​
, {​​​​​​​type=DECIMAL64, name=i_price, descending=false, nullLast=false}​​​​​​​, {​​​​​​​type=STRING, name=i_data, descending=false
, nullLast=false}​​​​​​​, {​​​​​​​type=INT64T, name=i_im_id, descending=false, nullLast=false}​​​​​​​}​​​​​​​, partitionKeyFields={​​​​​​​0, 1, 2}​​​​​​​
, rangeKeyFields={​​​​​​​}​​​​​​​}​​​​​​​
