### PR TITLE
try to update catalog version only in dml write with catalog changed set to true

### DIFF
--- a/pgtest/pg_run.sh
+++ b/pgtest/pg_run.sh
@@ -16,7 +16,7 @@ export K2_CPO_TIMEOUT=100ms
 export K2_CPO_BACKOFF=100ms
 export K2_MSG_CHECKSUM=TRUE
 export K2_CONFIG_FILE=/build/pgtest/k2config.json
-export K2_LOG_LEVEL="INFO k2::pggate=DEBUG k2::pg_catalog=DEBUG k2::tsoclient=INFO k2::cpo_client=INFO k2::transport=INFO"
+export K2_LOG_LEVEL="INFO k2::pggate=INFO k2::pg_catalog=INFO k2::tsoclient=INFO k2::cpo_client=INFO k2::transport=INFO"
 
 export GLOG_logtostderr=1 # log all to stderr
 export GLOG_v=5 #

--- a/src/k2/connector/yb/pggate/catalog/sql_catalog_client.cc
+++ b/src/k2/connector/yb/pggate/catalog/sql_catalog_client.cc
@@ -185,7 +185,7 @@ Status SqlCatalogClient::OpenTable(const PgOid database_oid, const PgOid table_o
   };
   auto start = k2::Clock::now();
   GetTableSchemaResponse response = catalog_manager_->GetTableSchema(request);
-  K2LOG_I(log::catalog, "GetTableSchema {} : {} took {}", database_oid, table_oid, k2::Clock::now() - start);
+  K2LOG_I(log::catalog, "GetTableSchema ({} : {}) took {}", database_oid, table_oid, k2::Clock::now() - start);
   if (!response.status.IsSucceeded()) {
      return STATUS_FORMAT(RuntimeError,
          "Failed to get schema for table $0 due to code $1 and message $2", table_oid, response.status.code, response.status.errorMessage);
@@ -227,10 +227,20 @@ Status SqlCatalogClient::GetCatalogVersion(uint64_t *pg_catalog_version) {
          "Failed to get catalog version due to code $0 and message $1", response.status.code, response.status.errorMessage);
   }
   *pg_catalog_version = response.catalogVersion;
-
   return Status::OK();
 }
 
+Status SqlCatalogClient::IncrementCatalogVersion() {
+  IncrementCatalogVersionRequest request;
+  auto start = k2::Clock::now();
+  IncrementCatalogVersionResponse response = catalog_manager_->IncrementCatalogVersion(request);
+  K2LOG_I(log::catalog, "IncrementCatalogVersion took {}", k2::Clock::now() - start);
+  if(!response.status.IsSucceeded()) {
+     return STATUS_FORMAT(RuntimeError,
+         "Failed to increase catalog version due to code $0 and message $1", response.status.code, response.status.errorMessage);
+  }
+  return Status::OK();
+}
 } // namespace catalog
 }  // namespace sql
 }  // namespace k2pg

--- a/src/k2/connector/yb/pggate/catalog/sql_catalog_client.h
+++ b/src/k2/connector/yb/pggate/catalog/sql_catalog_client.h
@@ -106,6 +106,8 @@ class SqlCatalogClient {
 
     CHECKED_STATUS GetCatalogVersion(uint64_t *pg_catalog_version);
 
+    CHECKED_STATUS IncrementCatalogVersion();
+
     private:
     std::shared_ptr<SqlCatalogManager> catalog_manager_;
 };

--- a/src/k2/connector/yb/pggate/catalog/sql_catalog_manager.h
+++ b/src/k2/connector/yb/pggate/catalog/sql_catalog_manager.h
@@ -261,6 +261,14 @@ namespace catalog {
         uint32_t endOid;
     };
 
+    struct IncrementCatalogVersionRequest {
+    };
+
+    struct IncrementCatalogVersionResponse {
+        RStatus status;
+        uint64_t version;
+    };
+
     class SqlCatalogManager : public std::enable_shared_from_this<SqlCatalogManager> {
 
     public:
@@ -283,6 +291,8 @@ namespace catalog {
         GetInitDbResponse IsInitDbDone(const GetInitDbRequest& request);
 
         GetCatalogVersionResponse GetCatalogVersion(const GetCatalogVersionRequest& request);
+
+        IncrementCatalogVersionResponse IncrementCatalogVersion(const IncrementCatalogVersionRequest& request);
 
         CreateNamespaceResponse CreateNamespace(const CreateNamespaceRequest& request);
 
@@ -336,8 +346,6 @@ namespace catalog {
         std::shared_ptr<IndexInfo> GetCachedIndexInfoById(const std::string& index_uuid);
 
         std::shared_ptr<SessionTransactionContext> NewTransactionContext();
-
-        RStatus IncreaseCatalogVersion(std::shared_ptr<SessionTransactionContext> context);
 
         IndexInfo BuildIndexInfo(std::shared_ptr<TableInfo> base_table_info, std::string index_name, uint32_t table_oid, std::string index_uuid,
                 const Schema& index_schema, bool is_unique, bool is_shared, IndexPermissions index_permissions);

--- a/src/k2/connector/yb/pggate/pg_dml_write.cc
+++ b/src/k2/connector/yb/pggate/pg_dml_write.cc
@@ -114,6 +114,9 @@ Status PgDmlWrite::Exec(bool force_non_bufferable) {
     rows_affected_count_ = VERIFY_RESULT(sql_op_->GetRowsAffectedCount());
   }
 
+  if (ysql_catalog_change_) {
+    RETURN_NOT_OK(pg_session_->GetCatalogClient()->IncrementCatalogVersion());
+  }
   return Status::OK();
 }
 

--- a/src/k2/connector/yb/pggate/pg_session.h
+++ b/src/k2/connector/yb/pggate/pg_session.h
@@ -310,6 +310,10 @@ class PgSession {
     return k2_adapter_->GetRowId(namespace_id, table_id, schema_version, key_values);
   }
 
+  std::shared_ptr<SqlCatalogClient> GetCatalogClient() {
+    return catalog_client_;
+  }
+
   private:
   // Helper class to run multiple operations on single session.
   // This class allows to keep implementation of RunAsync template method simple


### PR DESCRIPTION
The current catalog version update logic is directly controlled by catalog manager, which is inconsistent with PG internal logic. Change the catalog version logic to be triggered by PG, i.e., only update in DML write when the system catalog entries are updated and the following API is called to set the catalog version changed flag to true.

YBCStatus YBCPgSetIsSysCatalogVersionChange(YBCPgStatement handle);

Also fixed the catalog version update issue in catalog manager.