### PR TITLE
Sort out of order ops in condition expression

### DIFF
--- a/src/k2/connector/yb/pggate/pg_dml_read.h
+++ b/src/k2/connector/yb/pggate/pg_dml_read.h
@@ -122,8 +122,8 @@ class PgDmlRead : public PgDml {
   // Allocate column expression.
   std::shared_ptr<SqlOpExpr> AllocColumnAssignVar(PgColumn *col) override;
 
-  // Delete allocated target for columns that have no bind-values.
-  CHECKED_STATUS DeleteEmptyPrimaryBinds();
+  // Detect and set columns that have no bind-values.
+  CHECKED_STATUS SetUnboundPrimaryBinds();
 
   // References read request from template operation.
   std::shared_ptr<SqlOpReadRequest> read_req_ = nullptr;

--- a/src/k2/connector/yb/pggate/pg_op.h
+++ b/src/k2/connector/yb/pggate/pg_op.h
@@ -250,7 +250,7 @@ protected:
     // Parallelism level.
     // - This is the maximum number of read/write requests being sent to servers at one time.
     // - When it is 1, there's no optimization. Available requests is executed one at a time.
-    int32_t parallelism_level_ = 1;
+    int32_t parallelism_level_ = 100;
 
 private:
     // Result set either from selected or returned targets is cached in a list of strings.

--- a/src/k2/connector/yb/pggate/pg_op_api.h
+++ b/src/k2/connector/yb/pggate/pg_op_api.h
@@ -64,7 +64,8 @@ namespace gate {
             COLUMN_ID,
             BIND_ID,
             ALIAS_ID,
-            CONDITION
+            CONDITION,
+            UNBOUND
         );
 
         SqlOpExpr(ExprType type, std::shared_ptr<SqlValue> value) : type_(type), value_(value) {


### PR DESCRIPTION
Convert attribute number to column ID in condition expression
Support unbound primary columns if a prefix can be formed