### PR TITLE
allow primary key bindings to be passed in Foreign data wrapper for scan

### DIFF
--- a/pgtest/initDB.sh
+++ b/pgtest/initDB.sh
@@ -9,7 +9,7 @@ export YB_PG_ALLOW_RUNNING_AS_ANY_USER=1
 #export K2_HUGE_PAGES=TRUE
 export K2_CPO_ADDRESS=tcp+k2rpc://0.0.0.0:9000
 export K2_TSO_ADDRESS=tcp+k2rpc://0.0.0.0:13000
-export K2_PG_CORES=10
+export K2_PG_CORES=1
 #export K2_PG_CORES="1 2 4 10"
 
 export K2_PG_MEM=1G
@@ -30,6 +30,6 @@ rm -rf pgroot/data
 mkdir -p pgroot/data
 
 ./run_k2_platform.sh
-sleep 2
+sleep 5
 
 /build/src/k2/postgres/bin/initdb --locale=C -D pgroot/data

--- a/pgtest/pg_run.sh
+++ b/pgtest/pg_run.sh
@@ -8,7 +8,7 @@ export YB_PG_ALLOW_RUNNING_AS_ANY_USER=1
 #export K2_HUGE_PAGES=TRUE
 export K2_CPO_ADDRESS=tcp+k2rpc://0.0.0.0:9000
 export K2_TSO_ADDRESS=tcp+k2rpc://0.0.0.0:13000
-export K2_PG_CORES=10
+export K2_PG_CORES=1
 #export K2_PG_CORES="1 2 4 10"
 
 export K2_PG_MEM=2G

--- a/pgtest/run_k2_platform.sh
+++ b/pgtest/run_k2_platform.sh
@@ -10,7 +10,7 @@ rm -rf ${CPODIR}
 export PATH=${PATH}:/usr/local/bin
 
 # start CPO
-cpo_main -c1 --tcp_endpoints ${K2_CPO_ADDRESS} --data_dir ${CPODIR} --enable_tx_checksum true --reactor-backend epoll --prometheus_port 63000 --heartbeat_deadline=60s &
+cpo_main -c1 --tcp_endpoints ${K2_CPO_ADDRESS} --data_dir ${CPODIR} --enable_tx_checksum true --reactor-backend epoll --prometheus_port 63000 --heartbeat_deadline=300s &
 cpo_child_pid=$!
 
 # start nodepool


### PR DESCRIPTION
1) classify scan_clause into remote_exprs
2) parse remote_exprs for equal conditions
3) bind primary keys for equal conditions