### PR TITLE
Update run scripts after heartbeat fix

### DIFF
--- a/pgtest/run_k2_platform.sh
+++ b/pgtest/run_k2_platform.sh
@@ -10,17 +10,17 @@ rm -rf ${CPODIR}
 export PATH=${PATH}:/usr/local/bin
 
 # start CPO
-cpo_main -c1 --tcp_endpoints ${K2_CPO_ADDRESS} --data_dir ${CPODIR} --enable_tx_checksum true --reactor-backend epoll --prometheus_port 63000 --heartbeat_deadline=300s &
+cpo_main -c1 --tcp_endpoints ${K2_CPO_ADDRESS} --data_dir ${CPODIR} --enable_tx_checksum true --reactor-backend epoll --prometheus_port 63000 --heartbeat_deadline=2s --thread-affinity false &
 cpo_child_pid=$!
 
 # start nodepool
-nodepool -c4 --tcp_endpoints ${EPS} --enable_tx_checksum true --k23si_persistence_endpoint ${PERSISTENCE} --reactor-backend epoll --prometheus_port 63001 --k23si_cpo_endpoint ${K2_CPO_ADDRESS} --tso_endpoint ${K2_TSO_ADDRESS} -m16G &
+nodepool -c4 --tcp_endpoints ${EPS} --enable_tx_checksum true --k23si_persistence_endpoint ${PERSISTENCE} --prometheus_port 63001 --k23si_cpo_endpoint ${K2_CPO_ADDRESS} --tso_endpoint ${K2_TSO_ADDRESS} -m16G --thread-affinity false &
 nodepool_child_pid=$!
 
 # start persistence
-persistence -c1 --tcp_endpoints ${PERSISTENCE} --enable_tx_checksum true --reactor-backend epoll --prometheus_port 63002 &
+persistence -c1 --tcp_endpoints ${PERSISTENCE} --enable_tx_checksum true --prometheus_port 63002 --thread-affinity false &
 persistence_child_pid=$!
 
 # start tso
-tso -c2 --tcp_endpoints ${K2_TSO_ADDRESS} 13001 --enable_tx_checksum true --reactor-backend epoll --prometheus_port 63003 &
+tso -c2 --tcp_endpoints ${K2_TSO_ADDRESS} 13001 --enable_tx_checksum true --reactor-backend epoll --prometheus_port 63003 --thread-affinity false &
 tso_child_pid=$!

--- a/pgtest/run_k2_platform_rdma.sh
+++ b/pgtest/run_k2_platform_rdma.sh
@@ -18,7 +18,7 @@ rm -rf ${CPODIR}
 export PATH=${PATH}:/usr/local/bin
 
 # start CPO
-cpo_main -c1 --cpuset=0 --tcp_endpoints ${K2_CPO_ADDRESS} --data_dir ${CPODIR} --enable_tx_checksum true --prometheus_port 63000 --heartbeat_deadline=30s ${RDMA[@]} -m1G &
+cpo_main -c1 --cpuset=0 --tcp_endpoints ${K2_CPO_ADDRESS} --data_dir ${CPODIR} --enable_tx_checksum true --prometheus_port 63000 --heartbeat_deadline=1s ${RDMA[@]} -m1G &
 cpo_child_pid=$!
 
 # start nodepool


### PR DESCRIPTION
After platform heartbeat fix, I ran initDB over TCP three time successfully with 2s heartbeat. This also adds theard-affinity=false to the platform run scripts.