### PR TITLE
disable function pushdown for K2 platform temporarily

### DIFF
--- a/src/k2/postgres/src/backend/optimizer/util/ybcplan.c
+++ b/src/k2/postgres/src/backend/optimizer/util/ybcplan.c
@@ -231,31 +231,14 @@ void YBCExprInstantiateParams(Expr* expr, ParamListInfo paramLI)
  * The main current limitation is that DocDB's execution layer does not have
  * syscatalog access (cache lookup) so only specific builtins are supported.q
  */
-static bool YBCIsSupportedDocDBFunctionId(Oid funcid, Form_pg_proc pg_proc) {
-	if (!is_builtin_func(funcid))
-	{
-		return false;
-	}
-
-	/*
-	 * Polymorhipc pseduo-types (e.g. anyarray) may require additional
-	 * processing (requiring syscatalog access) to fully resolve to a concrete
-	 * type. Therefore they are not supported by DocDB.
-	 */
-	if (IsPolymorphicType(pg_proc->prorettype))
-	{
-		return false;
-	}
-
-	for (int i = 0; i < pg_proc->pronargs; i++)
-	{
-		if (IsPolymorphicType(pg_proc->proargtypes.values[i]))
-		{
-			return false;
-		}
-	}
-
-	return true;
+static bool IsSupportedK2FunctionId(Oid funcid, Form_pg_proc pg_proc) {
+	// Will add logic to enable the support to push down functions once
+	// K2 platform implements the function support.
+	//
+	// See
+	//   https://github.com/futurewei-cloud/chogori-platform/issues/137
+	//
+	return false;
 }
 
 static bool YBCAnalyzeExpression(Expr *expr, AttrNumber target_attnum, bool *has_vars, bool *has_docdb_unsupported_funcs) {
@@ -322,7 +305,7 @@ static bool YBCAnalyzeExpression(Expr *expr, AttrNumber target_attnum, bool *has
 				return false;
 			}
 
-			if (!YBCIsSupportedDocDBFunctionId(funcid, pg_proc)) {
+			if (!IsSupportedK2FunctionId(funcid, pg_proc)) {
 				*has_docdb_unsupported_funcs = true;
 			}
 			ReleaseSysCache(tuple);


### PR DESCRIPTION
Disable function pushdown in Query plan phase and will re-enable and add the support once K2 platform supports function pushdown.

Before the change, the function was pushed down and the query plan is a single update. 

postgres=# explain Update DISTRICT SET D_NEXT_O_ID = D_NEXT_O_ID + 1 WHERE D_W_ID = 1 AND D_ID = 2;
QUERY PLAN
Update on district (cost=0.00..4.12 rows=1 width=346)
-> Result (cost=0.00..4.12 rows=1 width=346)

Ran "Update DISTRICT SET D_NEXT_O_ID = D_NEXT_O_ID + 1 WHERE D_W_ID = 1 AND D_ID = 2;" would lead to exceptions. 

More details in https://github.com/futurewei-cloud/chogori-sql/issues/192.

After the change, the query plan was changed. The query will do a scan before apply the function to the result, which is not efficient, of course.

postgres=# explain Update DISTRICT  SET D_NEXT_O_ID = D_NEXT_O_ID + 1 WHERE D_W_ID = 1 AND D_ID =  2;
                                      QUERY PLAN                                      
--------------------------------------------------------------------------------------
 Update on district  (cost=0.00..4.12 rows=1 width=346)
   ->  Index Scan using district_pkey on district  (cost=0.00..4.12 rows=1 width=346)
         Index Cond: ((d_w_id = 1) AND (d_id = 2))

The query also ran fine now.

postgres=# explain analyze Update DISTRICT  SET D_NEXT_O_ID = D_NEXT_O_ID + 1 WHERE D_W_ID = 1 AND D_ID =  2;
                                                           QUERY PLAN                                                         
  
------------------------------------------------------------------------------------------------------------------------------
--
 Update on district  (cost=0.00..4.12 rows=1 width=346) (actual time=11.085..11.089 rows=0 loops=1)
   ->  Index Scan using district_pkey on district  (cost=0.00..4.12 rows=1 width=346) (actual time=2.214..2.232 rows=1 loops=1
)
         Index Cond: ((d_w_id = 1) AND (d_id = 2))
 Planning Time: 0.157 ms
 Execution Time: 11.351 ms
(5 rows)

postgres=#  Update DISTRICT  SET D_NEXT_O_ID = D_NEXT_O_ID + 1 WHERE D_W_ID = 1 AND D_ID =  2;
UPDATE 1
