### PR TITLE
disable aggregation pushdown temporarily since K2 platform does not support them yet

### DIFF
--- a/src/k2/postgres/contrib/yb_pg_metrics/yb_pg_metrics.c
+++ b/src/k2/postgres/contrib/yb_pg_metrics/yb_pg_metrics.c
@@ -475,7 +475,7 @@ ybpgm_ExecutorEnd(QueryDesc *queryDesc)
 	  ybpgm_Store(Transaction, time);
 
 	if (IsA(queryDesc->planstate, AggState) &&
-		castNode(AggState, queryDesc->planstate)->yb_pushdown_supported)
+		castNode(AggState, queryDesc->planstate)->k2_pushdown_supported)
 	  ybpgm_Store(AggregatePushdown, time);
   }
 

--- a/src/k2/postgres/src/backend/executor/ybc_fdw.c
+++ b/src/k2/postgres/src/backend/executor/ybc_fdw.c
@@ -1571,7 +1571,7 @@ ybcSetupScanTargets(ForeignScanState *node)
 					if (IsA(tle->expr, Const))
 					{
 						Const* const_node = castNode(Const, tle->expr);
-						/* Already checked by yb_agg_pushdown_supported */
+						/* Already checked by k2_agg_pushdown_supported */
 						Assert(const_node->constisnull || const_node->constbyval);
 
 						YBCPgExpr const_handle;

--- a/src/k2/postgres/src/include/nodes/execnodes.h
+++ b/src/k2/postgres/src/include/nodes/execnodes.h
@@ -142,7 +142,7 @@ typedef struct ExprState
  *		Am					Oid of index AM
  *		AmCache				private cache area for index AM
  *		Context				memory context holding this IndexInfo
- *		SplitOptions		Options to split index into tablets. 
+ *		SplitOptions		Options to split index into tablets.
  *
  * ii_Concurrent, ii_BrokenHotChain, and ii_ParallelWorkers are used only
  * during index build; they're conventionally zeroed otherwise.
@@ -1967,8 +1967,8 @@ typedef struct AggState
 										 * ->hash_pergroup */
 	ProjectionInfo *combinedproj;	/* projection machinery */
 
-	/* YB specific attributes. */
-	bool		yb_pushdown_supported;	/* YB pushdown supported for agg */
+	/* K2 specific attributes. */
+	bool		k2_pushdown_supported;	/* K2 pushdown supported for agg */
 } AggState;
 
 /* ----------------


### PR DESCRIPTION
Disable aggregation pushdown for now and resolve the count() issue 

https://github.com/futurewei-cloud/chogori-sql/issues/202

Before the fix,

postgres=# select count(d_w_id) from district;
WARNING: FDW: No remote exprs to bind keys for relation: 16417
ERROR: Internal error: Unexpected expression, only column refs supported in SKV

After the fix

The following statements worked,

postgres=# select count(d_w_id) from district;
WARNING:  FDW: No remote exprs to bind keys for relation: 16417
 count 
-------
     2
(1 row)

postgres=# explain analyze select count(d_w_id) from district;
WARNING:  FDW: No remote exprs to bind keys for relation: 16417
                                                   QUERY PLAN                                                    
-----------------------------------------------------------------------------------------------------------------
 Aggregate  (cost=102.50..102.51 rows=1 width=8) (actual time=2.068..2.076 rows=1 loops=1)
   ->  Foreign Scan on district  (cost=0.00..100.00 rows=1000 width=4) (actual time=1.995..2.021 rows=2 loops=1)
 Planning Time: 0.074 ms
 Execution Time: 2.177 ms
(4 rows)

postgres=# explain analyze select count(*) from district;
WARNING:  FDW: No remote exprs to bind keys for relation: 16417
                                                   QUERY PLAN                                                    
-----------------------------------------------------------------------------------------------------------------
 Aggregate  (cost=102.50..102.51 rows=1 width=8) (actual time=2.758..2.765 rows=1 loops=1)
   ->  Foreign Scan on district  (cost=0.00..100.00 rows=1000 width=0) (actual time=2.718..2.740 rows=2 loops=1)
 Planning Time: 9.434 ms
 Execution Time: 2.864 ms
(4 rows)

postgres=# explain analyze select count(1) from district;
WARNING:  FDW: No remote exprs to bind keys for relation: 16417
                                                   QUERY PLAN                                                    
-----------------------------------------------------------------------------------------------------------------
 Aggregate  (cost=102.50..102.51 rows=1 width=8) (actual time=1.736..1.746 rows=1 loops=1)
   ->  Foreign Scan on district  (cost=0.00..100.00 rows=1000 width=0) (actual time=1.661..1.680 rows=2 loops=1)
 Planning Time: 0.048 ms
 Execution Time: 1.816 ms
(4 rows)
