### PR TITLE
use datum directly for text or varchar data types to fix Segfault on prefix scan

### DIFF
--- a/src/k2/postgres/src/backend/executor/ybc_fdw.c
+++ b/src/k2/postgres/src/backend/executor/ybc_fdw.c
@@ -937,7 +937,7 @@ static void parse_const(Const *node, FDWExprRefValues *ref_values) {
 	if (node->constisnull || node->constbyval)
 		val->value = node->constvalue;
 	else
-		val->value = datumCopy(node->constvalue, node->constbyval, node->constlen);
+		val->value = PointerGetDatum(node->constvalue);
 
 	ref_values->const_values = lappend(ref_values->const_values, val);
 }

--- a/test/integration/compoundkey.py
+++ b/test/integration/compoundkey.py
@@ -42,7 +42,6 @@ class TestCompoundKey(unittest.TestCase):
         # TODO delete table
         cls.sharedConn.close()
 
-    @unittest.skip("Fails and causes other tests to fail. See issue #219 and #216")
     def test_prefixScanThreeKeys(self):
         # Populate some records for the tests
         with self.sharedConn: # commits at end of context if no errors
@@ -107,7 +106,6 @@ class TestCompoundKey(unittest.TestCase):
                     self.assertEqual(record[1], i)
                     self.assertEqual(record[2], 2)
 
-    @unittest.skip("Fails and causes other tests to fail. See issue #219 and #216")
     def test_prefixScanTxtTxt(self):
         # Populate some records for the tests
         with self.sharedConn: # commits at end of context if no errors


### PR DESCRIPTION
The issue was the text/varchar field type value copy. After the fix all tests passed and TPCC benchmark still works.

# ./integrate.py -v
test_count (aggregate.TestAggregation) ... ok
test_countWithFilter (aggregate.TestAggregation) ... ok
test_max (aggregate.TestAggregation) ... ok
test_min (aggregate.TestAggregation) ... ok
test_sum (aggregate.TestAggregation) ... ok
test_prefixScanBoolInt (compoundkey.TestCompoundKey) ... ok
test_prefixScanIntInt (compoundkey.TestCompoundKey) ... ok
test_prefixScanThreeKeys (compoundkey.TestCompoundKey) ... ok
test_prefixScanTxtTxt (compoundkey.TestCompoundKey) ... ok
test_alterTable (ddl.TestDDL) ... ok
test_makeBasicTable (ddl.TestDDL) ... ok
test_makeTableWithManyTypes (ddl.TestDDL) ... ok
test_makeTableWithoutPrimaryKey (ddl.TestDDL) ... ok
test_basicInsertAndRead (dmlbasic.TestDMLBasic) ... ok
test_basicProjection (dmlbasic.TestDMLBasic) ... ok
test_bulkUpdate (dmlbasic.TestDMLBasic) ... ok
test_delete (dmlbasic.TestDMLBasic) ... ok
test_insertIntoTwoTables (dmlbasic.TestDMLBasic) ... ok
test_insertOverExisting (dmlbasic.TestDMLBasic) ... ok
test_insertOverExistingDoNothing (dmlbasic.TestDMLBasic) ... ok
test_null (dmlbasic.TestDMLBasic) ... ok
test_readNonExistentRecord (dmlbasic.TestDMLBasic) ... ok
test_scan (dmlbasic.TestDMLBasic) ... ok
test_scanWithProjection (dmlbasic.TestDMLBasic) ... ok
test_selectWithFieldReference (dmlbasic.TestDMLBasic) ... ok
test_selectWithFunction (dmlbasic.TestDMLBasic) ... ok
test_singleRecordUpdate (dmlbasic.TestDMLBasic) ... ok
test_updateWithFieldReference (dmlbasic.TestDMLBasic) ... ok
test_conflict (isolation.TestIsolation) ... ok
test_mvccRead (isolation.TestIsolation) ... ok
test_readYourDelete (isolation.TestIsolation) ... ok
test_readYourWrite (isolation.TestIsolation) ... ok
test_rollback (isolation.TestIsolation) ... ok
test_innerJoin (join.TestJoin) ... ok
test_joinPreTest (join.TestJoin) ... ok

----------------------------------------------------------------------
Ran 35 tests in 44.310s

OK