### PR TITLE
change to use PgExpr as pg dml request targets directly

### DIFF
--- a/src/k2/connector/pggate/pg_dml.h
+++ b/src/k2/connector/pggate/pg_dml.h
@@ -143,8 +143,8 @@ class PgDml : public PgStatement {
         const PgObjectId& index_object_id,
         const PgPrepareParameters *prepare_params);
 
-  // Allocate doc expression for a SELECTed expression.
-  virtual std::shared_ptr<SqlOpExpr> AllocTargetVar() = 0;
+  // Get target vector
+  virtual std::vector<PgExpr *>& GetTargets() = 0;
 
   // Allocate doc expression for expression whose value is bounded to a column.
   virtual std::shared_ptr<SqlOpExpr> AllocColumnBindVar(PgColumn *col) = 0;

--- a/src/k2/connector/pggate/pg_dml_read.cc
+++ b/src/k2/connector/pggate/pg_dml_read.cc
@@ -87,11 +87,8 @@ std::shared_ptr<SqlOpCondition> PgDmlRead::AllocColumnBindConditionExprVar(PgCol
   return col->AllocBindConditionExpr(read_req_);
 }
 
-// Allocate variable for target.
-std::shared_ptr<SqlOpExpr> PgDmlRead::AllocTargetVar() {
-  std::shared_ptr<SqlOpExpr> target = std::make_shared<SqlOpExpr>();
-  read_req_->targets.push_back(target);
-  return target;
+std::vector<PgExpr *>& PgDmlRead::GetTargets() {
+  return read_req_->targets;
 }
 
 // Allocate column expression.

--- a/src/k2/connector/pggate/pg_dml_read.h
+++ b/src/k2/connector/pggate/pg_dml_read.h
@@ -124,8 +124,8 @@ class PgDmlRead : public PgDml {
   std::shared_ptr<SqlOpExpr> AllocColumnBindVar(PgColumn *col) override;
   std::shared_ptr<SqlOpCondition> AllocColumnBindConditionExprVar(PgColumn *col);
 
-  // Allocate variable for target.
-  std::shared_ptr<SqlOpExpr> AllocTargetVar() override;
+  // get target vectors
+  std::vector<PgExpr *>& GetTargets() override;
 
   // Allocate column expression.
   std::shared_ptr<SqlOpExpr> AllocColumnAssignVar(PgColumn *col) override;

--- a/src/k2/connector/pggate/pg_dml_write.cc
+++ b/src/k2/connector/pggate/pg_dml_write.cc
@@ -174,10 +174,8 @@ std::shared_ptr<SqlOpExpr> PgDmlWrite::AllocColumnAssignVar(PgColumn *col) {
   return col->AllocAssign(write_req_);
 }
 
-std::shared_ptr<SqlOpExpr> PgDmlWrite::AllocTargetVar() {
-  std::shared_ptr<SqlOpExpr> target_var = std::make_shared<SqlOpExpr>();
-  write_req_->targets.push_back(target_var);
-  return target_var;
+std::vector<PgExpr *>& PgDmlWrite::GetTargets() {
+  return write_req_->targets;
 }
 
 Status PgDmlWrite::SetWriteTime(const uint64_t write_time) {

--- a/src/k2/connector/pggate/pg_dml_write.h
+++ b/src/k2/connector/pggate/pg_dml_write.h
@@ -98,8 +98,8 @@ class PgDmlWrite : public PgDml {
   // Allocate column expression.
   std::shared_ptr<SqlOpExpr> AllocColumnBindVar(PgColumn *col) override;
 
-  // Allocate target for selected or returned expressions.
-  std::shared_ptr<SqlOpExpr> AllocTargetVar() override;
+  // Get target vector
+  std::vector<PgExpr *>& GetTargets() override;
 
   // Allocate column expression.
   std::shared_ptr<SqlOpExpr> AllocColumnAssignVar(PgColumn *col) override;

--- a/src/k2/connector/pggate/pg_op_api.h
+++ b/src/k2/connector/pggate/pg_op_api.h
@@ -236,8 +236,7 @@ namespace gate {
         std::vector<std::shared_ptr<SqlOpExpr>> ybctid_column_values;
 
         // Projection, aggregate, etc.
-        std::vector<std::shared_ptr<SqlOpExpr>> targets;
-
+        std::vector<PgExpr *> targets;
         PgExpr* range_conds;
         PgExpr* where_conds;
 
@@ -284,7 +283,7 @@ namespace gate {
         // - Columns to be overwritten (UPDATE SET clause). This field can contain primary-key columns.
         std::vector<ColumnValue> column_new_values;
         // K2 SKV does not support the following three cluases for writes:
-        std::vector<std::shared_ptr<SqlOpExpr>> targets;
+        std::vector<PgExpr *> targets;
         std::shared_ptr<SqlOpExpr> where_expr;
         std::shared_ptr<SqlOpCondition> condition_expr;
 


### PR DESCRIPTION
This is one of the steps to remove SqlOpExpr and use PgExpr directly. 
This PR is to change the targets in the dml read/write request to use PgExpr directly.

Tested with TPCC and integration tests.

# ./integrate.py -v
test_count (aggregate.TestAggregation) ... ok
test_countWithFilter (aggregate.TestAggregation) ... ok
test_max (aggregate.TestAggregation) ... ok
test_min (aggregate.TestAggregation) ... ok
test_sum (aggregate.TestAggregation) ... ok
test_prefixScanBoolInt (compoundkey.TestCompoundKey) ... ok
test_prefixScanIntInt (compoundkey.TestCompoundKey) ... ok
test_prefixScanThreeKeys (compoundkey.TestCompoundKey) ... ok
test_prefixScanTxtTxt (compoundkey.TestCompoundKey) ... ok
test_alterTable (ddl.TestDDL) ... ok
test_makeBasicTable (ddl.TestDDL) ... ok
test_makeTableWithManyTypes (ddl.TestDDL) ... ok
test_makeTableWithoutPrimaryKey (ddl.TestDDL) ... ok
test_basicInsertAndRead (dmlbasic.TestDMLBasic) ... ok
test_basicProjection (dmlbasic.TestDMLBasic) ... ok
test_bulkUpdate (dmlbasic.TestDMLBasic) ... ok
test_delete (dmlbasic.TestDMLBasic) ... ok
test_insertIntoTwoTables (dmlbasic.TestDMLBasic) ... ok
test_insertOverExisting (dmlbasic.TestDMLBasic) ... ok
test_insertOverExistingDoNothing (dmlbasic.TestDMLBasic) ... ok
test_null (dmlbasic.TestDMLBasic) ... ok
test_readNonExistentRecord (dmlbasic.TestDMLBasic) ... ok
test_scan (dmlbasic.TestDMLBasic) ... ok
test_scanWithProjection (dmlbasic.TestDMLBasic) ... ok
test_selectWithFieldReference (dmlbasic.TestDMLBasic) ... ok
test_selectWithFunction (dmlbasic.TestDMLBasic) ... ok
test_singleRecordUpdate (dmlbasic.TestDMLBasic) ... ok
test_updateWithFieldReference (dmlbasic.TestDMLBasic) ... ok
test_conflict (isolation.TestIsolation) ... ok
test_mvccRead (isolation.TestIsolation) ... ok
test_readYourDelete (isolation.TestIsolation) ... ok
test_readYourWrite (isolation.TestIsolation) ... ok
test_rollback (isolation.TestIsolation) ... ok
test_innerJoin (join.TestJoin) ... ok
test_joinPreTest (join.TestJoin) ... ok

----------------------------------------------------------------------
Ran 35 tests in 48.934s

OK