### PR TITLE
Fix filter operand ordering (fixes yb_pg_int8)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -54,4 +54,5 @@ ExternalProject_Add(
     CONFIGURE_COMMAND ${CMAKE_CURRENT_SOURCE_DIR}/src/k2/postgres/configure_helper.sh    ${CMAKE_CURRENT_SOURCE_DIR}/src/k2/postgres    "-DSEASTAR_API_LEVEL=6 -lybpggate -lybcommon -lk2entities  -lgflags -lybutf -lprom -lpromhttp -lmicrohttpd -std=gnu++17"     "-L/usr/local/lib/k2/ -L${CMAKE_CURRENT_SOURCE_DIR}/build/src/k2/connector/common -L${CMAKE_CURRENT_SOURCE_DIR}/build/src/k2/connector/entities -L${CMAKE_CURRENT_SOURCE_DIR}/build/src/k2/connector/pggate -L${CMAKE_CURRENT_SOURCE_DIR}/build/src/k2/connector/utf"      "-I${CMAKE_CURRENT_SOURCE_DIR}/src/k2/connector"     <INSTALL_DIR>
     PREFIX ${CMAKE_CURRENT_SOURCE_DIR}/src/k2/postgres
     EXCLUDE_FROM_ALL 1
+    BUILD_ALWAYS 1
     BUILD_COMMAND make -j -f Makefile installcheck "PG_CPP_LIBS=-lybpggate -lk2entities -lk23si_client -lcpo_client -ltso_client -ldto -lappbase -ltransport -lcrc32c -lconfig -lcommon -lseastar -lboost_thread -lyaml-cpp -lboost_program_options -lfmt -libverbs -lhwloc -lnuma -lcrypto++ -ldl -lrt -lprotobuf -lgnutls -lprom -lpromhttp -lmicrohttpd")

--- a/src/k2/postgres/src/test/regress/chogori_schedule
+++ b/src/k2/postgres/src/test/regress/chogori_schedule
@@ -4,13 +4,11 @@
 # Postgres Testsuites: Porting from PostgreSQL original tests.
 # This suite includes all tests on numeric datatypes that are enabled for YugaByte.
 ####################################################################################################
-test: yb_oid
 test: yb_int2
 test: yb_pg_int4
 test: yb_pg_int8
 test: yb_numeric
 test: yb_numeric_big
-test: yb_money
 # src/test/regress/yb_pg_type_serial_schedule
 #
 ####################################################################################################


### PR DESCRIPTION
Also remove tests that use a primary key type we don't support