### PR TITLE
Do not shutdown other clients on crash

### DIFF
--- a/pgtest/pg_run.sh
+++ b/pgtest/pg_run.sh
@@ -3,6 +3,7 @@ export LD_LIBRARY_PATH=/build/build/src/k2/connector/common/:/build/build/src/k2
 export YB_ENABLED_IN_POSTGRES=1
 export YB_PG_TRANSACTIONS_ENABLED=1
 export YB_PG_ALLOW_RUNNING_AS_ANY_USER=1
+export PG_NO_RESTART_ALL_CHILDREN_ON_CRASH=1
 
 export K2_CONFIG_FILE=/build/pgtest/k2config_pgrun.json
 

--- a/src/k2/postgres/src/backend/utils/misc/pg_yb_utils.c
+++ b/src/k2/postgres/src/backend/utils/misc/pg_yb_utils.c
@@ -547,11 +547,11 @@ YBShouldRestartAllChildrenIfOneCrashes() {
 		ereport(LOG, (errmsg("YBShouldRestartAllChildrenIfOneCrashes returning 0, YBIsEnabledInPostgresEnvVar is false")));
 		return true;
 	}
-	const char* flag_file_path =
-		getenv("YB_PG_NO_RESTART_ALL_CHILDREN_ON_CRASH_FLAG_PATH");
+	const char* flag =
+		getenv("PG_NO_RESTART_ALL_CHILDREN_ON_CRASH");
 	// We will use PostgreSQL's default behavior (restarting all children if one of them crashes)
-	// if the flag env variable is not specified or the file pointed by it does not exist.
-	return !flag_file_path || access(flag_file_path, F_OK) == -1;
+	// if the flag env variable is not specified
+	return !flag;
 }
 
 bool


### PR DESCRIPTION
We do not have shared memory between postgres backend instances, so it is safe to configure PG to not kill them on a crash. closes #216 