### PR TITLE
change limit to infinite for reverse index scan

### DIFF
--- a/src/k2/connector/pggate/k2_adapter.cc
+++ b/src/k2/connector/pggate/k2_adapter.cc
@@ -655,7 +655,10 @@ CBFuture<Status> K2Adapter::handleReadOp(std::shared_ptr<K23SITxn> k23SITxn,
                 }
             }
 
-            // We are explicitly not setting the limit on the query. See issue #278
+            // this is a total limit.
+            if (request->limit > 0) {
+                scan->setLimit(request->limit);
+            }
         }
 
         k2::QueryResult scan_result = k23SITxn->scanRead(scan).get();

--- a/src/k2/postgres/src/backend/access/ybc/ybcin.c
+++ b/src/k2/postgres/src/backend/access/ybc/ybcin.c
@@ -303,6 +303,11 @@ ybcingettuple(IndexScanDesc scan, ScanDirection dir)
 
 	CamScanDesc ybscan = (CamScanDesc) scan->opaque;
 	ybscan->exec_params = scan->k2pg_exec_params;
+	if (!is_forward_scan) {
+		// Ignore limit count for reverse scan since K2 PG cannot push down the limit for reverse scan and
+		// rely on PG to process the limit count
+		ybscan->exec_params->limit_count = -1;
+	}
 	Assert(PointerIsValid(ybscan));
 
 	/*


### PR DESCRIPTION
From the investigation of issue https://github.com/futurewei-cloud/chogori-sql/issues/279, the reverse index scan was actually called from ybcin.c, not the ybc_fdw.c. Revert the change of ignoring all limits in k2_adapter.cc and set the limit to infinite for reverse index scan in ybcin.c instead since we don't have the correct logic to filter out result set for reverse scan in K2 or PgGate. 

Tests
---------
CREATE TABLE reverse_scan_test (
h BIGINT,
r INT,
PRIMARY KEY(h, r ASC)
);

INSERT INTO reverse_scan_test
VALUES (1, 1),
(1, 2),
(1, 3),
(1, 4),
(1, 5),
(1, 6),
(1, 7),
(1, 8),
(1, 9),
(1, 10),
(1, 11),
(1, 12),
(1, 13),
(1, 14);

Before the fix (with the rollback of k2 adapter)

postgres=# SELECT r FROM reverse_scan_test WHERE h = 1 AND r < 9 ORDER BY r DESC LIMIT 5;
 r 
---
(0 rows)

postgres=# SELECT r FROM reverse_scan_test WHERE h = 1 AND r >= 3 and r <= 13 ORDER BY r DESC LIMIT 8;
 r  
----
 13
 12
 11
 10
  9
  8
  7
(7 rows)

After the fix

postgres=# SELECT r FROM reverse_scan_test WHERE h = 1 AND r < 9 ORDER BY r DESC LIMIT 5;
 r 
---
 8
 7
 6
 5
 4
(5 rows)

postgres=# SELECT r FROM reverse_scan_test WHERE h = 1 AND r >= 3 and r <= 13 ORDER BY r DESC LIMIT 8;
 r  
----
 13
 12
 11
 10
  9
  8
  7
  6
(8 rows)

