### PR TITLE
Add needed license (for new files) or copyright (for modified files)

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -5,6 +5,8 @@ The subproject located in src/k2/postgres is licensed as follows:
 PostgreSQL Database Management System
 (formerly known as Postgres, then as Postgres95)
 
+Portions Copyright (c) 2021 Futurewei Cloud
+
 Portions Copyright (c) 1996-2019, PostgreSQL Global Development Group
 
 Portions Copyright (c) 1994, The Regents of the University of California
@@ -28,11 +30,46 @@ PROVIDE MAINTENANCE, SUPPORT, UPDATES, ENHANCEMENTS, OR MODIFICATIONS.
 ==========================================================================
 
 
+Portions of the subproject located in src/k2/connector are licensed as:
+==========================================================================
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+
+The following only applies to changes made to this file as part of YugaByte development.
+
+Portions Copyright (c) YugaByte, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+in compliance with the License.  You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under the License
+is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+or implied.  See the License for the specific language governing permissions and limitations
+under the License.
+==========================================================================
+
+
 The remaining codebase is licensed as follows:
 ==========================================================================
 MIT License
 
-Copyright (c) 2020 Futurewei Cloud
+Copyright (c) 2021 Futurewei Cloud
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/pgtest/Logging.cpp
+++ b/pgtest/Logging.cpp
@@ -1,3 +1,20 @@
+// Copyright(c) 2021 Futurewei Cloud
+//
+// Permission is hereby granted,
+//        free of charge, to any person obtaining a copy of this software and associated documentation files(the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and / or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions :
+//
+// The above copyright notice and this permission notice shall be included in all copies
+// or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS",
+// WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.IN NO EVENT SHALL THE
+//        AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+//        DAMAGES OR OTHER LIABILITY,
+// WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+//
+
 #include "Logging.h"
 
 namespace k2 {

--- a/pgtest/Logging.h
+++ b/pgtest/Logging.h
@@ -1,4 +1,22 @@
+// Copyright(c) 2021 Futurewei Cloud
+//
+// Permission is hereby granted,
+//        free of charge, to any person obtaining a copy of this software and associated documentation files(the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and / or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions :
+//
+// The above copyright notice and this permission notice shall be included in all copies
+// or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS",
+// WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.IN NO EVENT SHALL THE
+//        AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+//        DAMAGES OR OTHER LIABILITY,
+// WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+//
+
 #pragma once
+
 #include <pthread.h>
 
 #include <chrono>

--- a/pgtest/pg_test.cpp
+++ b/pgtest/pg_test.cpp
@@ -1,3 +1,21 @@
+// Copyright(c) 2021 Futurewei Cloud
+//
+// Permission is hereby granted,
+//        free of charge, to any person obtaining a copy of this software and associated documentation files(the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and / or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions :
+//
+// The above copyright notice and this permission notice shall be included in all copies
+// or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS",
+// WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.IN NO EVENT SHALL THE
+//        AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+//        DAMAGES OR OTHER LIABILITY,
+// WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+//
+
+
 // compile with
 // export K2PG_COMPILER_TYPE=gcc
 // export LD_LIBRARY_PATH=/build/build/src/k2/connector/common/:/build/build/src/k2/connector/entities/:/build/src/k2/postgres/lib

--- a/src/k2/connector/common/alignment.h
+++ b/src/k2/connector/common/alignment.h
@@ -15,6 +15,8 @@
 // specific language governing permissions and limitations
 // under the License.
 //
+// Portions Copyright (c) 2021 Futurewei Cloud
+//
 // The following only applies to changes made to this file as part of YugaByte development.
 //
 // Portions Copyright (c) YugaByte, Inc.

--- a/src/k2/connector/common/endian.h
+++ b/src/k2/connector/common/endian.h
@@ -17,6 +17,8 @@
 // specific language governing permissions and limitations
 // under the License.
 //
+// Portions Copyright (c) 2021 Futurewei Cloud
+//
 // The following only applies to changes made to this file as part of YugaByte development.
 //
 // Portions Copyright (c) YugaByte, Inc.

--- a/src/k2/connector/common/errno.cc
+++ b/src/k2/connector/common/errno.cc
@@ -15,6 +15,8 @@
 // specific language governing permissions and limitations
 // under the License.
 //
+// Portions Copyright (c) 2021 Futurewei Cloud
+//
 // The following only applies to changes made to this file as part of YugaByte development.
 //
 // Portions Copyright (c) YugaByte, Inc.

--- a/src/k2/connector/common/errno.h
+++ b/src/k2/connector/common/errno.h
@@ -15,6 +15,8 @@
 // specific language governing permissions and limitations
 // under the License.
 //
+// Portions Copyright (c) 2021 Futurewei Cloud
+//
 // The following only applies to changes made to this file as part of YugaByte development.
 //
 // Portions Copyright (c) YugaByte, Inc.

--- a/src/k2/connector/common/flag_tags.cc
+++ b/src/k2/connector/common/flag_tags.cc
@@ -15,6 +15,8 @@
 // specific language governing permissions and limitations
 // under the License.
 //
+// Portions Copyright (c) 2021 Futurewei Cloud
+//
 // The following only applies to changes made to this file as part of YugaByte development.
 //
 // Portions Copyright (c) YugaByte, Inc.

--- a/src/k2/connector/common/flag_tags.h
+++ b/src/k2/connector/common/flag_tags.h
@@ -15,6 +15,8 @@
 // specific language governing permissions and limitations
 // under the License.
 //
+// Portions Copyright (c) 2021 Futurewei Cloud
+//
 // The following only applies to changes made to this file as part of YugaByte development.
 //
 // Portions Copyright (c) YugaByte, Inc.

--- a/src/k2/connector/common/k2pg-internal.cc
+++ b/src/k2/connector/common/k2pg-internal.cc
@@ -1,4 +1,5 @@
 // Copyright (c) YugaByte, Inc.
+// Portions Copyright (c) 2021 Futurewei Cloud
 //
 // Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
 // in compliance with the License.  You may obtain a copy of the License at

--- a/src/k2/connector/common/k2pg-internal.h
+++ b/src/k2/connector/common/k2pg-internal.h
@@ -1,4 +1,5 @@
 // Copyright (c) YugaByte, Inc.
+// Portions Copyright (c) 2021 Futurewei Cloud
 //
 // Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
 // in compliance with the License.  You may obtain a copy of the License at

--- a/src/k2/connector/common/k2pg_errcodes.h
+++ b/src/k2/connector/common/k2pg_errcodes.h
@@ -12,6 +12,8 @@
 //
 // Portions Copyright (c) 1996-2018, PostgreSQL Global Development Group
 // Portions Copyright (c) 1994, Regents of the University of California
+// Portions Copyright (c) 2021 Futurewei Cloud
+
 #pragma once
 
 #include <stdint.h>

--- a/src/k2/connector/common/k2pg_util.cc
+++ b/src/k2/connector/common/k2pg_util.cc
@@ -1,4 +1,5 @@
 // Copyright (c) YugaByte, Inc.
+// Portions Copyright (c) 2021 Futurewei Cloud
 //
 // Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
 // in compliance with the License.  You may obtain a copy of the License at

--- a/src/k2/connector/common/k2pg_util.h
+++ b/src/k2/connector/common/k2pg_util.h
@@ -1,4 +1,5 @@
 // Copyright (c) YugaByte, Inc.
+// Portions Copyright (c) 2021 Futurewei Cloud
 //
 // Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
 // in compliance with the License.  You may obtain a copy of the License at

--- a/src/k2/connector/common/malloc.cc
+++ b/src/k2/connector/common/malloc.cc
@@ -15,6 +15,8 @@
 // specific language governing permissions and limitations
 // under the License.
 //
+// Portions Copyright (c) 2021 Futurewei Cloud
+//
 // The following only applies to changes made to this file as part of YugaByte development.
 //
 // Portions Copyright (c) YugaByte, Inc.

--- a/src/k2/connector/common/malloc.h
+++ b/src/k2/connector/common/malloc.h
@@ -15,6 +15,8 @@
 // specific language governing permissions and limitations
 // under the License.
 //
+// Portions Copyright (c) 2021 Futurewei Cloud
+//
 // The following only applies to changes made to this file as part of YugaByte development.
 //
 // Portions Copyright (c) YugaByte, Inc.

--- a/src/k2/connector/common/pgsql_error.cc
+++ b/src/k2/connector/common/pgsql_error.cc
@@ -1,4 +1,5 @@
 // Copyright (c) YugaByte, Inc.
+// Portions Copyright (c) 2021 Futurewei Cloud
 //
 // Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
 // in compliance with the License.  You may obtain a copy of the License at

--- a/src/k2/connector/common/pgsql_error.h
+++ b/src/k2/connector/common/pgsql_error.h
@@ -1,4 +1,5 @@
 // Copyright (c) YugaByte, Inc.
+// Portions Copyright (c) 2021 Futurewei Cloud
 //
 // Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
 // in compliance with the License.  You may obtain a copy of the License at

--- a/src/k2/connector/common/port.h
+++ b/src/k2/connector/common/port.h
@@ -1,6 +1,8 @@
 //
 // Copyright (C) 1999 and onwards Google, Inc.
 //
+// Portions Copyright (c) 2021 Futurewei Cloud
+//
 // The following only applies to changes made to this file as part of YugaByte development.
 //
 // Portions Copyright (c) YugaByte, Inc.

--- a/src/k2/connector/common/result.h
+++ b/src/k2/connector/common/result.h
@@ -1,5 +1,6 @@
 //
 // Copyright (c) YugaByte, Inc.
+// Portions Copyright (c) 2021 Futurewei Cloud
 //
 // Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
 // in compliance with the License.  You may obtain a copy of the License at

--- a/src/k2/connector/common/scope_exit.h
+++ b/src/k2/connector/common/scope_exit.h
@@ -1,4 +1,5 @@
 // Copyright (c) YugaByte, Inc.
+// Portions Copyright (c) 2021 Futurewei Cloud
 //
 // Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
 // in compliance with the License.  You may obtain a copy of the License at

--- a/src/k2/connector/common/status.cc
+++ b/src/k2/connector/common/status.cc
@@ -2,6 +2,8 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file. See the AUTHORS file for names of contributors.
 //
+// Portions Copyright (c) 2021 Futurewei Cloud
+//
 // The following only applies to changes made to this file as part of YugaByte development.
 //
 // Portions Copyright (c) YugaByte, Inc.

--- a/src/k2/connector/common/status.h
+++ b/src/k2/connector/common/status.h
@@ -2,6 +2,8 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file. See the AUTHORS file for names of contributors.
 //
+// Portions Copyright (c) 2021 Futurewei Cloud
+//
 // The following only applies to changes made to this file as part of YugaByte development.
 //
 // Portions Copyright (c) YugaByte, Inc.

--- a/src/k2/connector/common/stol_utils.cc
+++ b/src/k2/connector/common/stol_utils.cc
@@ -1,4 +1,5 @@
 // Copyright (c) YugaByte, Inc.
+// Portions Copyright (c) 2021 Futurewei Cloud
 //
 // Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
 // in compliance with the License.  You may obtain a copy of the License at

--- a/src/k2/connector/common/stol_utils.h
+++ b/src/k2/connector/common/stol_utils.h
@@ -1,4 +1,5 @@
 // Copyright (c) YugaByte, Inc.
+// Portions Copyright (c) 2021 Futurewei Cloud
 //
 // Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
 // in compliance with the License.  You may obtain a copy of the License at

--- a/src/k2/connector/common/transaction_error.cc
+++ b/src/k2/connector/common/transaction_error.cc
@@ -1,4 +1,5 @@
 // Copyright (c) YugaByte, Inc.
+// Portions Copyright (c) 2021 Futurewei Cloud
 //
 // Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
 // in compliance with the License.  You may obtain a copy of the License at

--- a/src/k2/connector/common/transaction_error.h
+++ b/src/k2/connector/common/transaction_error.h
@@ -1,4 +1,5 @@
 // Copyright (c) YugaByte, Inc.
+// Portions Copyright (c) 2021 Futurewei Cloud
 //
 // Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
 // in compliance with the License.  You may obtain a copy of the License at

--- a/src/k2/connector/common/type/decimal.cc
+++ b/src/k2/connector/common/type/decimal.cc
@@ -1,4 +1,5 @@
 // Copyright (c) YugaByte, Inc.
+// Portions Copyright (c) 2021 Futurewei Cloud
 //
 // Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
 // in compliance with the License.  You may obtain a copy of the License at

--- a/src/k2/connector/common/type/decimal.h
+++ b/src/k2/connector/common/type/decimal.h
@@ -1,4 +1,5 @@
 // Copyright (c) YugaByte, Inc.
+// Portions Copyright (c) 2021 Futurewei Cloud
 //
 // Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
 // in compliance with the License.  You may obtain a copy of the License at

--- a/src/k2/connector/common/type/int128.cc
+++ b/src/k2/connector/common/type/int128.cc
@@ -1,6 +1,8 @@
 // Copyright 2004 Google Inc.
 // All Rights Reserved.
 //
+// Portions Copyright (c) 2021 Futurewei Cloud
+//
 // The following only applies to changes made to this file as part of YugaByte development.
 //
 // Portions Copyright (c) YugaByte, Inc.

--- a/src/k2/connector/common/type/int128.h
+++ b/src/k2/connector/common/type/int128.h
@@ -1,6 +1,8 @@
 // Copyright 2004 Google Inc.
 // All Rights Reserved.
 //
+// Portions Copyright (c) 2021 Futurewei Cloud
+//
 // The following only applies to changes made to this file as part of YugaByte development.
 //
 // Portions Copyright (c) YugaByte, Inc.

--- a/src/k2/connector/common/type/integral_types.h
+++ b/src/k2/connector/common/type/integral_types.h
@@ -1,5 +1,7 @@
 // Copyright 2010 Google Inc. All Rights Reserved.
 //
+// Portions Copyright (c) 2021 Futurewei Cloud
+//
 // The following only applies to changes made to this file as part of YugaByte development.
 //
 // Portions Copyright (c) YugaByte, Inc.

--- a/src/k2/connector/common/type/slice.cc
+++ b/src/k2/connector/common/type/slice.cc
@@ -15,6 +15,8 @@
 // specific language governing permissions and limitations
 // under the License.
 //
+// Portions Copyright (c) 2021 Futurewei Cloud
+//
 // The following only applies to changes made to this file as part of YugaByte development.
 //
 // Portions Copyright (c) YugaByte, Inc.

--- a/src/k2/connector/common/type/slice.h
+++ b/src/k2/connector/common/type/slice.h
@@ -2,6 +2,8 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file. See the AUTHORS file for names of contributors.
 //
+// Portions Copyright (c) 2021 Futurewei Cloud
+//
 // The following only applies to changes made to this file as part of YugaByte development.
 //
 // Portions Copyright (c) YugaByte, Inc.

--- a/src/k2/connector/common/type/varint.cc
+++ b/src/k2/connector/common/type/varint.cc
@@ -1,4 +1,5 @@
 // Copyright (c) YugaByte, Inc.
+// Portions Copyright (c) 2021 Futurewei Cloud
 //
 // Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
 // in compliance with the License.  You may obtain a copy of the License at

--- a/src/k2/connector/common/type/varint.h
+++ b/src/k2/connector/common/type/varint.h
@@ -1,4 +1,5 @@
 // Copyright (c) YugaByte, Inc.
+// Portions Copyright (c) 2021 Futurewei Cloud
 //
 // Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
 // in compliance with the License.  You may obtain a copy of the License at

--- a/src/k2/connector/entities/entity_ids.cc
+++ b/src/k2/connector/entities/entity_ids.cc
@@ -1,4 +1,5 @@
 // Copyright (c) YugaByte, Inc.
+// Portions Copyright (c) 2021 Futurewei Cloud
 //
 // Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
 // in compliance with the License.  You may obtain a copy of the License at

--- a/src/k2/connector/entities/entity_ids.h
+++ b/src/k2/connector/entities/entity_ids.h
@@ -15,6 +15,8 @@
 // specific language governing permissions and limitations
 // under the License.
 //
+// Portions Copyright (c) 2021 Futurewei Cloud
+//
 // The following only applies to changes made to this file as part of YugaByte development.
 //
 // Portions Copyright (c) YugaByte, Inc.

--- a/src/k2/connector/entities/expr.cc
+++ b/src/k2/connector/entities/expr.cc
@@ -15,6 +15,8 @@
 // specific language governing permissions and limitations
 // under the License.
 //
+// Portions Copyright (c) 2021 Futurewei Cloud
+//
 // The following only applies to changes made to this file as part of YugaByte development.
 //
 // Portions Copyright (c) YugaByte, Inc.

--- a/src/k2/connector/entities/expr.h
+++ b/src/k2/connector/entities/expr.h
@@ -15,6 +15,8 @@
 // specific language governing permissions and limitations
 // under the License.
 //
+// Portions Copyright (c) 2021 Futurewei Cloud
+//
 // The following only applies to changes made to this file as part of YugaByte development.
 //
 // Portions Copyright (c) YugaByte, Inc.

--- a/src/k2/connector/entities/index.cc
+++ b/src/k2/connector/entities/index.cc
@@ -15,6 +15,8 @@
 // specific language governing permissions and limitations
 // under the License.
 //
+// Portions Copyright (c) 2021 Futurewei Cloud
+//
 // The following only applies to changes made to this file as part of YugaByte development.
 //
 // Portions Copyright (c) YugaByte, Inc.

--- a/src/k2/connector/entities/index.h
+++ b/src/k2/connector/entities/index.h
@@ -15,6 +15,8 @@
 // specific language governing permissions and limitations
 // under the License.
 //
+// Portions Copyright (c) 2021 Futurewei Cloud
+//
 // The following only applies to changes made to this file as part of YugaByte development.
 //
 // Portions Copyright (c) YugaByte, Inc.

--- a/src/k2/connector/entities/schema.cc
+++ b/src/k2/connector/entities/schema.cc
@@ -15,6 +15,8 @@
 // specific language governing permissions and limitations
 // under the License.
 //
+// Portions Copyright (c) 2021 Futurewei Cloud
+//
 // The following only applies to changes made to this file as part of YugaByte development.
 //
 // Portions Copyright (c) YugaByte, Inc.

--- a/src/k2/connector/entities/schema.h
+++ b/src/k2/connector/entities/schema.h
@@ -15,6 +15,8 @@
 // specific language governing permissions and limitations
 // under the License.
 //
+// Portions Copyright (c) 2021 Futurewei Cloud
+//
 // The following only applies to changes made to this file as part of YugaByte development.
 //
 // Portions Copyright (c) YugaByte, Inc.

--- a/src/k2/connector/entities/type.cc
+++ b/src/k2/connector/entities/type.cc
@@ -15,6 +15,8 @@
 // specific language governing permissions and limitations
 // under the License.
 //
+// Portions Copyright (c) 2021 Futurewei Cloud
+//
 // The following only applies to changes made to this file as part of YugaByte development.
 //
 // Portions Copyright (c) YugaByte, Inc.

--- a/src/k2/connector/entities/type.h
+++ b/src/k2/connector/entities/type.h
@@ -15,6 +15,8 @@
 // specific language governing permissions and limitations
 // under the License.
 //
+// Portions Copyright (c) 2021 Futurewei Cloud
+//
 // The following only applies to changes made to this file as part of YugaByte development.
 //
 // Portions Copyright (c) YugaByte, Inc.

--- a/src/k2/connector/entities/types.cc
+++ b/src/k2/connector/entities/types.cc
@@ -15,6 +15,8 @@
 // specific language governing permissions and limitations
 // under the License.
 //
+// Portions Copyright (c) 2021 Futurewei Cloud
+//
 // The following only applies to changes made to this file as part of YugaByte development.
 //
 // Portions Copyright (c) YugaByte, Inc.

--- a/src/k2/connector/entities/types.h
+++ b/src/k2/connector/entities/types.h
@@ -15,6 +15,8 @@
 // specific language governing permissions and limitations
 // under the License.
 //
+// Portions Copyright (c) 2021 Futurewei Cloud
+//
 // The following only applies to changes made to this file as part of YugaByte development.
 //
 // Portions Copyright (c) YugaByte, Inc.

--- a/src/k2/connector/pggate/catalog/catalog_log.h
+++ b/src/k2/connector/pggate/catalog/catalog_log.h
@@ -1,4 +1,28 @@
+/*
+MIT License
+
+Copyright(c) 2020 Futurewei Cloud
+
+    Permission is hereby granted,
+    free of charge, to any person obtaining a copy of this software and associated documentation files(the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and / or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions :
+
+    The above copyright notice and this permission notice shall be included in all copies
+    or
+    substantial portions of the Software.
+
+    THE SOFTWARE IS PROVIDED "AS IS",
+    WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+    FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.IN NO EVENT SHALL THE
+    AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+    DAMAGES OR OTHER
+    LIABILITY,
+    WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+    OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+    SOFTWARE.
+*/
+
 #pragma once
+
 #include <k2/common/Log.h>
 
 namespace k2pg::sql::catalog::log {

--- a/src/k2/connector/pggate/k2_adapter.cc
+++ b/src/k2/connector/pggate/k2_adapter.cc
@@ -1,3 +1,10 @@
+// Copyright(c) 2021 Futurewei Cloud
+//
+// Permission is hereby granted,
+//        free of charge, to any person obtaining a copy of this software and associated documentation files(the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and / or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions :
+//
+// The above copyright notice and this permission notice shall be included in all copies
+// or substantial portions of the Software.
 //
 // THE SOFTWARE IS PROVIDED "AS IS",
 // WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
@@ -6,7 +13,7 @@
 //        DAMAGES OR OTHER LIABILITY,
 // WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-//
+
 #include "k2_adapter.h"
 
 #include <unordered_map>

--- a/src/k2/connector/pggate/k2_config.cc
+++ b/src/k2/connector/pggate/k2_config.cc
@@ -1,3 +1,10 @@
+// Copyright(c) 2021 Futurewei Cloud
+//
+// Permission is hereby granted,
+//        free of charge, to any person obtaining a copy of this software and associated documentation files(the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and / or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions :
+//
+// The above copyright notice and this permission notice shall be included in all copies
+// or substantial portions of the Software.
 //
 // THE SOFTWARE IS PROVIDED "AS IS",
 // WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
@@ -6,7 +13,7 @@
 //        DAMAGES OR OTHER LIABILITY,
 // WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-//
+
 #include "k2_config.h"
 #include "k2_includes.h"
 

--- a/src/k2/connector/pggate/k2_config.h
+++ b/src/k2/connector/pggate/k2_config.h
@@ -1,3 +1,10 @@
+// Copyright(c) 2021 Futurewei Cloud
+//
+// Permission is hereby granted,
+//        free of charge, to any person obtaining a copy of this software and associated documentation files(the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and / or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions :
+//
+// The above copyright notice and this permission notice shall be included in all copies
+// or substantial portions of the Software.
 //
 // THE SOFTWARE IS PROVIDED "AS IS",
 // WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
@@ -6,7 +13,7 @@
 //        DAMAGES OR OTHER LIABILITY,
 // WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-//
+
 #pragma once
 
 #include <nlohmann/json.hpp>

--- a/src/k2/connector/pggate/k2_future.h
+++ b/src/k2/connector/pggate/k2_future.h
@@ -1,4 +1,21 @@
+// Copyright(c) 2021 Futurewei Cloud
+//
+// Permission is hereby granted,
+//        free of charge, to any person obtaining a copy of this software and associated documentation files(the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and / or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions :
+//
+// The above copyright notice and this permission notice shall be included in all copies
+// or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS",
+// WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.IN NO EVENT SHALL THE
+//        AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+//        DAMAGES OR OTHER LIABILITY,
+// WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
 #pragma once
+
 #include <future>
 
 namespace k2pg {
@@ -36,7 +53,7 @@ private:
     std::function<void(void)> _callback;
 };
 
-// Wrapper for std futures which allows a TransformFunc callback to be invoked 
+// Wrapper for std futures which allows a TransformFunc callback to be invoked
 // right after the future's blocking get() call returns, but before the user sees the result.
 // Useful for example for exception handling, return type conversion, reporting metrics on request durations, etc
 template <typename TransformFunc,  typename... T>

--- a/src/k2/connector/pggate/k2_includes.h
+++ b/src/k2/connector/pggate/k2_includes.h
@@ -1,3 +1,26 @@
+/*
+MIT License
+
+Copyright(c) 2020 Futurewei Cloud
+
+    Permission is hereby granted,
+    free of charge, to any person obtaining a copy of this software and associated documentation files(the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and / or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions :
+
+    The above copyright notice and this permission notice shall be included in all copies
+    or
+    substantial portions of the Software.
+
+    THE SOFTWARE IS PROVIDED "AS IS",
+    WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+    FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.IN NO EVENT SHALL THE
+    AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+    DAMAGES OR OTHER
+    LIABILITY,
+    WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+    OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+    SOFTWARE.
+*/
+
 #pragma once
 
 #include <k2/appbase/AppEssentials.h>

--- a/src/k2/connector/pggate/k2_log.h
+++ b/src/k2/connector/pggate/k2_log.h
@@ -1,3 +1,26 @@
+/*
+MIT License
+
+Copyright(c) 2021 Futurewei Cloud
+
+    Permission is hereby granted,
+    free of charge, to any person obtaining a copy of this software and associated documentation files(the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and / or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions :
+
+    The above copyright notice and this permission notice shall be included in all copies
+    or
+    substantial portions of the Software.
+
+    THE SOFTWARE IS PROVIDED "AS IS",
+    WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+    FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.IN NO EVENT SHALL THE
+    AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+    DAMAGES OR OTHER
+    LIABILITY,
+    WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+    OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+    SOFTWARE.
+*/
+
 #pragma once
 #include "k2_includes.h"
 

--- a/src/k2/connector/pggate/k2_log_init.h
+++ b/src/k2/connector/pggate/k2_log_init.h
@@ -1,3 +1,26 @@
+/*
+MIT License
+
+Copyright(c) 2021 Futurewei Cloud
+
+    Permission is hereby granted,
+    free of charge, to any person obtaining a copy of this software and associated documentation files(the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and / or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions :
+
+    The above copyright notice and this permission notice shall be included in all copies
+    or
+    substantial portions of the Software.
+
+    THE SOFTWARE IS PROVIDED "AS IS",
+    WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+    FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.IN NO EVENT SHALL THE
+    AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+    DAMAGES OR OTHER
+    LIABILITY,
+    WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+    OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+    SOFTWARE.
+*/
+
 #pragma once
 
 #include <sstream>

--- a/src/k2/connector/pggate/k2_metrics_api.h
+++ b/src/k2/connector/pggate/k2_metrics_api.h
@@ -1,3 +1,26 @@
+/*
+MIT License
+
+Copyright(c) 2021 Futurewei Cloud
+
+    Permission is hereby granted,
+    free of charge, to any person obtaining a copy of this software and associated documentation files(the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and / or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions :
+
+    The above copyright notice and this permission notice shall be included in all copies
+    or
+    substantial portions of the Software.
+
+    THE SOFTWARE IS PROVIDED "AS IS",
+    WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+    FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.IN NO EVENT SHALL THE
+    AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+    DAMAGES OR OTHER
+    LIABILITY,
+    WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+    OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+    SOFTWARE.
+*/
+
 #pragma once
 
 #include <string>

--- a/src/k2/connector/pggate/k2_session_metrics.h
+++ b/src/k2/connector/pggate/k2_session_metrics.h
@@ -1,3 +1,26 @@
+/*
+MIT License
+
+Copyright(c) 2021 Futurewei Cloud
+
+    Permission is hereby granted,
+    free of charge, to any person obtaining a copy of this software and associated documentation files(the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and / or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions :
+
+    The above copyright notice and this permission notice shall be included in all copies
+    or
+    substantial portions of the Software.
+
+    THE SOFTWARE IS PROVIDED "AS IS",
+    WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+    FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.IN NO EVENT SHALL THE
+    AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+    DAMAGES OR OTHER
+    LIABILITY,
+    WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+    OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+    SOFTWARE.
+*/
+
 #pragma once
 
 #include "k2_metrics_api.h"

--- a/src/k2/connector/pggate/pg_column.cc
+++ b/src/k2/connector/pggate/pg_column.cc
@@ -15,6 +15,8 @@
 // specific language governing permissions and limitations
 // under the License.
 //
+// Portions Copyright (c) 2021 Futurewei Cloud
+//
 // The following only applies to changes made to this file as part of YugaByte development.
 //
 // Portions Copyright (c) YugaByte, Inc.
@@ -28,23 +30,6 @@
 // is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
 // or implied.  See the License for the specific language governing permissions and limitations
 // under the License.
-//
-// Copyright(c) 2020 Futurewei Cloud
-//
-// Permission is hereby granted,
-//        free of charge, to any person obtaining a copy of this software and associated documentation files(the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and / or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions :
-//
-// The above copyright notice and this permission notice shall be included in all copies
-// or substantial portions of the Software.
-//
-// THE SOFTWARE IS PROVIDED "AS IS",
-// WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.IN NO EVENT SHALL THE
-//        AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
-//        DAMAGES OR OTHER LIABILITY,
-// WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-//
 
 #include "pggate/pg_column.h"
 #include "pggate/pg_gate_typedefs.h"

--- a/src/k2/connector/pggate/pg_column.h
+++ b/src/k2/connector/pggate/pg_column.h
@@ -15,6 +15,8 @@
 // specific language governing permissions and limitations
 // under the License.
 //
+// Portions Copyright (c) 2021 Futurewei Cloud
+//
 // The following only applies to changes made to this file as part of YugaByte development.
 //
 // Portions Copyright (c) YugaByte, Inc.
@@ -28,23 +30,7 @@
 // is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
 // or implied.  See the License for the specific language governing permissions and limitations
 // under the License.
-//
-// Copyright(c) 2020 Futurewei Cloud
-//
-// Permission is hereby granted,
-//        free of charge, to any person obtaining a copy of this software and associated documentation files(the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and / or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions :
-//
-// The above copyright notice and this permission notice shall be included in all copies
-// or substantial portions of the Software.
-//
-// THE SOFTWARE IS PROVIDED "AS IS",
-// WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.IN NO EVENT SHALL THE
-//        AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
-//        DAMAGES OR OTHER LIABILITY,
-// WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-//
+
 #pragma once
 
 #include "entities/entity_ids.h"

--- a/src/k2/connector/pggate/pg_ddl.cc
+++ b/src/k2/connector/pggate/pg_ddl.cc
@@ -15,6 +15,8 @@
 // specific language governing permissions and limitations
 // under the License.
 //
+// Portions Copyright (c) 2021 Futurewei Cloud
+//
 // The following only applies to changes made to this file as part of YugaByte development.
 //
 // Portions Copyright (c) YugaByte, Inc.
@@ -28,23 +30,6 @@
 // is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
 // or implied.  See the License for the specific language governing permissions and limitations
 // under the License.
-//
-// Copyright(c) 2020 Futurewei Cloud
-//
-// Permission is hereby granted,
-//        free of charge, to any person obtaining a copy of this software and associated documentation files(the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and / or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions :
-//
-// The above copyright notice and this permission notice shall be included in all copies
-// or substantial portions of the Software.
-//
-// THE SOFTWARE IS PROVIDED "AS IS",
-// WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.IN NO EVENT SHALL THE
-//        AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
-//        DAMAGES OR OTHER LIABILITY,
-// WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-//
 
 #include "pggate/pg_ddl.h"
 #include "pggate/pg_gate_typedefs.h"

--- a/src/k2/connector/pggate/pg_ddl.h
+++ b/src/k2/connector/pggate/pg_ddl.h
@@ -15,6 +15,8 @@
 // specific language governing permissions and limitations
 // under the License.
 //
+// Portions Copyright (c) 2021 Futurewei Cloud
+//
 // The following only applies to changes made to this file as part of YugaByte development.
 //
 // Portions Copyright (c) YugaByte, Inc.
@@ -28,23 +30,7 @@
 // is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
 // or implied.  See the License for the specific language governing permissions and limitations
 // under the License.
-//
-// Copyright(c) 2020 Futurewei Cloud
-//
-// Permission is hereby granted,
-//        free of charge, to any person obtaining a copy of this software and associated documentation files(the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and / or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions :
-//
-// The above copyright notice and this permission notice shall be included in all copies
-// or substantial portions of the Software.
-//
-// THE SOFTWARE IS PROVIDED "AS IS",
-// WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.IN NO EVENT SHALL THE
-//        AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
-//        DAMAGES OR OTHER LIABILITY,
-// WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-//
+
 #pragma once
 
 #include <string>

--- a/src/k2/connector/pggate/pg_delete.h
+++ b/src/k2/connector/pggate/pg_delete.h
@@ -15,6 +15,8 @@
 // specific language governing permissions and limitations
 // under the License.
 //
+// Portions Copyright (c) 2021 Futurewei Cloud
+//
 // The following only applies to changes made to this file as part of YugaByte development.
 //
 // Portions Copyright (c) YugaByte, Inc.
@@ -28,23 +30,7 @@
 // is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
 // or implied.  See the License for the specific language governing permissions and limitations
 // under the License.
-//
-// Copyright(c) 2020 Futurewei Cloud
-//
-// Permission is hereby granted,
-//        free of charge, to any person obtaining a copy of this software and associated documentation files(the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and / or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions :
-//
-// The above copyright notice and this permission notice shall be included in all copies
-// or substantial portions of the Software.
-//
-// THE SOFTWARE IS PROVIDED "AS IS",
-// WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.IN NO EVENT SHALL THE
-//        AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
-//        DAMAGES OR OTHER LIABILITY,
-// WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-//
+
 #pragma once
 
 #include "pggate/pg_dml_write.h"

--- a/src/k2/connector/pggate/pg_env.h
+++ b/src/k2/connector/pggate/pg_env.h
@@ -1,5 +1,6 @@
 //--------------------------------------------------------------------------------------------------
 // Copyright (c) YugaByte, Inc.
+// Portions Copyright (c) 2021 Futurewei Cloud
 //
 // Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
 // in compliance with the License.  You may obtain a copy of the License at

--- a/src/k2/connector/pggate/pg_gate_api.cc
+++ b/src/k2/connector/pggate/pg_gate_api.cc
@@ -1,3 +1,26 @@
+/*
+MIT License
+
+Copyright(c) 2021 Futurewei Cloud
+
+    Permission is hereby granted,
+    free of charge, to any person obtaining a copy of this software and associated documentation files(the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and / or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions :
+
+    The above copyright notice and this permission notice shall be included in all copies
+    or
+    substantial portions of the Software.
+
+    THE SOFTWARE IS PROVIDED "AS IS",
+    WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+    FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.IN NO EVENT SHALL THE
+    AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+    DAMAGES OR OTHER
+    LIABILITY,
+    WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+    OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+    SOFTWARE.
+*/
+
 #include "pg_gate_api.h"
 
 #include "common/k2pg-internal.h"

--- a/src/k2/connector/pggate/pg_gate_api.h
+++ b/src/k2/connector/pggate/pg_gate_api.h
@@ -1,4 +1,5 @@
 // Copyright (c) YugaByte, Inc.
+// Portions Copyright (c) 2021 Futurewei Cloud
 //
 // Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
 // in compliance with the License.  You may obtain a copy of the License at

--- a/src/k2/connector/pggate/pg_gate_thread_local_vars.cc
+++ b/src/k2/connector/pggate/pg_gate_thread_local_vars.cc
@@ -1,5 +1,6 @@
 //--------------------------------------------------------------------------------------------------
 // Copyright (c) YugaByte, Inc.
+// Portions Copyright (c) 2021 Futurewei Cloud
 //
 // Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
 // in compliance with the License.  You may obtain a copy of the License at

--- a/src/k2/connector/pggate/pg_gate_thread_local_vars.h
+++ b/src/k2/connector/pggate/pg_gate_thread_local_vars.h
@@ -1,5 +1,6 @@
 //--------------------------------------------------------------------------------------------------
 // Copyright (c) YugaByte, Inc.
+// Portions Copyright (c) 2021 Futurewei Cloud
 //
 // Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
 // in compliance with the License.  You may obtain a copy of the License at

--- a/src/k2/connector/pggate/pg_gate_typedefs.h
+++ b/src/k2/connector/pggate/pg_gate_typedefs.h
@@ -1,4 +1,5 @@
 // Copyright (c) YugaByte, Inc.
+// Portions Copyright (c) 2021 Futurewei Cloud
 //
 // Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
 // in compliance with the License.  You may obtain a copy of the License at


### PR DESCRIPTION
Checked all changed/added files in src/k2/connector (see diff below). Updated top level license file.

git diff --name-only 43f2bec446d6cd640c14790efdfbe05306b6514f (diff from initial import of yb code):
.gitignore
CMakeLists.txt
docs/K2SqlDesign.md
docs/Performance.md
docs/images/CreateTableSeqDiagram.png
docs/images/K2SqlCatalogManagerCache021.png
docs/images/K2SqlCatalogService01.png
docs/images/K2SqlCatalogService021.png
docs/images/K2SqlClusterBootstrap021.png
docs/images/K2SqlCoordinatorAdditionalAPIs01.png
docs/images/K2SqlCoordinatorCache01.png
docs/images/K2SqlCoordinatorDiagram01.png
docs/images/K2SqlCreateDBTableIndexSequenceDiagram01.png
docs/images/K2SqlDocumentAPIs01.png
docs/images/K2SqlDocumentAPIs021.png
docs/images/K2SqlDocumentUserCase01.png
docs/images/K2SqlDropTableSequenceDiagram01.png
docs/images/K2SqlExecutorDiagram01.png
docs/images/K2SqlExecutorDiagram021.png
docs/images/K2SqlInsertSequenceDiagram01.png
docs/images/K2SqlRenameColumnSequenceDiagram01.png
docs/images/K2SqlSchemaDataPersistence01.png
docs/images/K2SqlSchemaDataPersistence021.png
docs/images/K2SqlSchemaEntity02.png
docs/images/K2SqlSelectSequenceDiagram02.png
docs/images/K2SqlSystemArchitecture01.png
docs/images/K2SqlSystemDiagram021.png
docs/images/Postgres Init Paths.gliffy
docs/images/Postgres Init Paths.png
docs/images/ScanFetchNextSeqDiagram.png
docs/images/YugabytedbPGIntegration.png
docs/images/cql_row_encoding.png
docs/images/pg_backend.gliffy
docs/images/pg_backend.png
docs/k2_pg_code_integration.md
pg_grafana_dashboard.json
pgtest/Logging.cpp
pgtest/Logging.h
pgtest/README.md
pgtest/docker-compose.yml
pgtest/initDB.sh
pgtest/initDB_rdma.sh
pgtest/k2config_initdb.json
pgtest/k2config_initdb_rdma.json
pgtest/k2config_pgrun.json
pgtest/k2config_pgrun_rdma.json
pgtest/pg_hba.conf
pgtest/pg_rdma.sh
pgtest/pg_run.sh
pgtest/pg_test.cpp
pgtest/pg_test.sh
pgtest/run_k2_platform.sh
pgtest/run_k2_platform_rdma.sh
src/k2/connector/CMakeLists.txt
src/k2/connector/common/CMakeLists.txt
src/k2/connector/common/alignment.h
src/k2/connector/common/common-utils.cc
src/k2/connector/common/common-utils.h
src/k2/connector/common/common_defs.h
src/k2/connector/common/endian.h
src/k2/connector/common/errno.cc
src/k2/connector/common/errno.h
src/k2/connector/common/flag_tags.cc
src/k2/connector/common/flag_tags.h
src/k2/connector/common/k2pg-internal.cc
src/k2/connector/common/k2pg-internal.h
src/k2/connector/common/k2pg_errcodes.h
src/k2/connector/common/k2pg_util.cc
src/k2/connector/common/k2pg_util.h
src/k2/connector/common/malloc.cc
src/k2/connector/common/malloc.h
src/k2/connector/common/pgsql_error.cc
src/k2/connector/common/pgsql_error.h
src/k2/connector/common/port.h
src/k2/connector/common/result.h
src/k2/connector/common/scope_exit.h
src/k2/connector/common/status.cc
src/k2/connector/common/status.h
src/k2/connector/common/stol_utils.cc
src/k2/connector/common/stol_utils.h
src/k2/connector/common/transaction_error.cc
src/k2/connector/common/transaction_error.h
src/k2/connector/common/type/decimal.cc
src/k2/connector/common/type/decimal.h
src/k2/connector/common/type/int128.cc
src/k2/connector/common/type/int128.h
src/k2/connector/common/type/integral_types.h
src/k2/connector/common/type/slice.cc
src/k2/connector/common/type/slice.h
src/k2/connector/common/type/varint.cc
src/k2/connector/common/type/varint.h
src/k2/connector/entities/CMakeLists.txt
src/k2/connector/entities/data_type.h
src/k2/connector/entities/entity_ids.cc
src/k2/connector/entities/entity_ids.h
src/k2/connector/entities/expr.cc
src/k2/connector/entities/expr.h
src/k2/connector/entities/index.cc
src/k2/connector/entities/index.h
src/k2/connector/entities/schema.cc
src/k2/connector/entities/schema.h
src/k2/connector/entities/table.cc
src/k2/connector/entities/table.h
src/k2/connector/entities/type.cc
src/k2/connector/entities/type.h
src/k2/connector/entities/types.cc
src/k2/connector/entities/types.h
src/k2/connector/entities/value.cc
src/k2/connector/entities/value.h
src/k2/connector/pggate/CMakeLists.txt
src/k2/connector/pggate/catalog/background_task.h
src/k2/connector/pggate/catalog/catalog_log.h
src/k2/connector/pggate/catalog/cluster_info_handler.cc
src/k2/connector/pggate/catalog/cluster_info_handler.h
src/k2/connector/pggate/catalog/database_info_handler.cc
src/k2/connector/pggate/catalog/database_info_handler.h
src/k2/connector/pggate/catalog/sql_catalog_client.cc
src/k2/connector/pggate/catalog/sql_catalog_client.h
src/k2/connector/pggate/catalog/sql_catalog_defaults.cc
src/k2/connector/pggate/catalog/sql_catalog_defaults.h
src/k2/connector/pggate/catalog/sql_catalog_entity.h
src/k2/connector/pggate/catalog/sql_catalog_manager.cc
src/k2/connector/pggate/catalog/sql_catalog_manager.h
src/k2/connector/pggate/catalog/table_info_handler.cc
src/k2/connector/pggate/catalog/table_info_handler.h
src/k2/connector/pggate/k2_adapter.cc
src/k2/connector/pggate/k2_adapter.h
src/k2/connector/pggate/k2_config.cc
src/k2/connector/pggate/k2_config.h
src/k2/connector/pggate/k2_future.h
src/k2/connector/pggate/k2_gate.cc
src/k2/connector/pggate/k2_gate.h
src/k2/connector/pggate/k2_includes.h
src/k2/connector/pggate/k2_log.h
src/k2/connector/pggate/k2_log_init.h
src/k2/connector/pggate/k2_metrics_api.h
src/k2/connector/pggate/k2_queue_defs.h
src/k2/connector/pggate/k2_seastar_app.cc
src/k2/connector/pggate/k2_seastar_app.h
src/k2/connector/pggate/k2_session_metrics.h
src/k2/connector/pggate/k2_thread_pool.h
src/k2/connector/pggate/k2_txn.cc
src/k2/connector/pggate/k2_txn.h
src/k2/connector/pggate/pg_column.cc
src/k2/connector/pggate/pg_column.h
src/k2/connector/pggate/pg_ddl.cc
src/k2/connector/pggate/pg_ddl.h
src/k2/connector/pggate/pg_delete.h

src/k2/connector/pggate/pg_dml.cc
src/k2/connector/pggate/pg_dml.h
src/k2/connector/pggate/pg_dml_read.cc
src/k2/connector/pggate/pg_dml_read.h
src/k2/connector/pggate/pg_dml_write.cc
src/k2/connector/pggate/pg_dml_write.h
src/k2/connector/pggate/pg_env.h
src/k2/connector/pggate/pg_gate_api.cc
src/k2/connector/pggate/pg_gate_api.h
src/k2/connector/pggate/pg_gate_defaults.h
src/k2/connector/pggate/pg_gate_impl.cc
src/k2/connector/pggate/pg_gate_impl.h
src/k2/connector/pggate/pg_gate_thread_local_vars.cc
src/k2/connector/pggate/pg_gate_thread_local_vars.h
src/k2/connector/pggate/pg_gate_typedefs.h
src/k2/connector/pggate/pg_insert.h
src/k2/connector/pggate/pg_memctx.cc
src/k2/connector/pggate/pg_memctx.h

src/k2/connector/pggate/pg_op.cc
src/k2/connector/pggate/pg_op.h
src/k2/connector/pggate/pg_op_api.cc
src/k2/connector/pggate/pg_op_api.h

src/k2/connector/pggate/pg_select.cc
src/k2/connector/pggate/pg_select.h
src/k2/connector/pggate/pg_session.cc
src/k2/connector/pggate/pg_session.h
src/k2/connector/pggate/pg_statement.cc
src/k2/connector/pggate/pg_statement.h
src/k2/connector/pggate/pg_tabledesc.cc
src/k2/connector/pggate/pg_tabledesc.h
src/k2/connector/pggate/pg_tuple.cc
src/k2/connector/pggate/pg_tuple.h
src/k2/connector/pggate/pg_txn_handler.cc
src/k2/connector/pggate/pg_txn_handler.h
src/k2/connector/pggate/pg_update.h
src/k2/connector/utf/CMakeLists.txt
src/k2/connector/utf/LICENSE
src/k2/connector/utf/rune.c
src/k2/connector/utf/utf.h
src/k2/connector/utf/utfdef.h
src/k2/postgres/CMakeLists.txt
src/k2/postgres/Makefile
src/k2/postgres/configure_helper.sh
src/k2/postgres/contrib/pg_stat_statements/Makefile
src/k2/postgres/contrib/pg_stat_statements/pg_stat_statements.c
src/k2/postgres/contrib/yb_pg_metrics/Makefile
src/k2/postgres/contrib/yb_pg_metrics/yb_pg_metrics.c
src/k2/postgres/src/Makefile.global.in
src/k2/postgres/src/backend/Makefile
src/k2/postgres/src/backend/access/common/heaptuple.c
src/k2/postgres/src/backend/access/heap/heapam.c
src/k2/postgres/src/backend/access/index/genam.c
src/k2/postgres/src/backend/access/index/indexam.c
src/k2/postgres/src/backend/access/transam/varsup.c
src/k2/postgres/src/backend/access/transam/xact.c
src/k2/postgres/src/backend/access/ybc/ybcam.c
src/k2/postgres/src/backend/access/ybc/ybcin.c
src/k2/postgres/src/backend/bootstrap/bootparse.y
src/k2/postgres/src/backend/bootstrap/bootscanner.l
src/k2/postgres/src/backend/bootstrap/bootstrap.c
src/k2/postgres/src/backend/bootstrap/ybcbootstrap.c
src/k2/postgres/src/backend/catalog/Makefile
src/k2/postgres/src/backend/catalog/aclchk.c
src/k2/postgres/src/backend/catalog/catalog.c
src/k2/postgres/src/backend/catalog/dependency.c
src/k2/postgres/src/backend/catalog/heap.c
src/k2/postgres/src/backend/catalog/index.c
src/k2/postgres/src/backend/catalog/indexing.c
src/k2/postgres/src/backend/catalog/k2pg_genbki.pl
src/k2/postgres/src/backend/catalog/k2pg_system_views.sql
src/k2/postgres/src/backend/catalog/pg_constraint.c
src/k2/postgres/src/backend/catalog/pg_depend.c
src/k2/postgres/src/backend/catalog/pg_type.c
src/k2/postgres/src/backend/catalog/toasting.c
src/k2/postgres/src/backend/catalog/ybctype.c
src/k2/postgres/src/backend/commands/analyze.c
src/k2/postgres/src/backend/commands/async.c
src/k2/postgres/src/backend/commands/copy.c
src/k2/postgres/src/backend/commands/createas.c
src/k2/postgres/src/backend/commands/dbcommands.c
src/k2/postgres/src/backend/commands/indexcmds.c
src/k2/postgres/src/backend/commands/schemacmds.c
src/k2/postgres/src/backend/commands/sequence.c
src/k2/postgres/src/backend/commands/tablecmds.c
src/k2/postgres/src/backend/commands/trigger.c
src/k2/postgres/src/backend/commands/typecmds.c
src/k2/postgres/src/backend/commands/vacuum.c
src/k2/postgres/src/backend/commands/variable.c
src/k2/postgres/src/backend/commands/ybccmds.c
src/k2/postgres/src/backend/executor/execIndexing.c
src/k2/postgres/src/backend/executor/execMain.c
src/k2/postgres/src/backend/executor/execProcnode.c
src/k2/postgres/src/backend/executor/execScan.c
src/k2/postgres/src/backend/executor/execUtils.c
src/k2/postgres/src/backend/executor/nodeAgg.c
src/k2/postgres/src/backend/executor/nodeForeignscan.c
src/k2/postgres/src/backend/executor/nodeIndexonlyscan.c
src/k2/postgres/src/backend/executor/nodeIndexscan.c
src/k2/postgres/src/backend/executor/nodeLimit.c
src/k2/postgres/src/backend/executor/nodeLockRows.c
src/k2/postgres/src/backend/executor/nodeModifyTable.c
src/k2/postgres/src/backend/executor/nodeSort.c
src/k2/postgres/src/backend/executor/ybcExpr.c
src/k2/postgres/src/backend/executor/ybcModifyTable.c
src/k2/postgres/src/backend/executor/ybc_fdw.c
src/k2/postgres/src/backend/foreign/foreign.c
src/k2/postgres/src/backend/libpq/pqcomm.c
src/k2/postgres/src/backend/main/Makefile
src/k2/postgres/src/backend/main/main.c
src/k2/postgres/src/backend/main/main_cpp_wrapper.cc
src/k2/postgres/src/backend/nodes/copyfuncs.c
src/k2/postgres/src/backend/nodes/equalfuncs.c
src/k2/postgres/src/backend/nodes/makefuncs.c
src/k2/postgres/src/backend/nodes/outfuncs.c
src/k2/postgres/src/backend/nodes/read.c
src/k2/postgres/src/backend/optimizer/path/allpaths.c
src/k2/postgres/src/backend/optimizer/path/costsize.c
src/k2/postgres/src/backend/optimizer/path/joinpath.c
src/k2/postgres/src/backend/optimizer/plan/createplan.c
src/k2/postgres/src/backend/optimizer/prep/preptlist.c
src/k2/postgres/src/backend/optimizer/util/pathnode.c
src/k2/postgres/src/backend/optimizer/util/plancat.c
src/k2/postgres/src/backend/optimizer/util/ybcplan.c
src/k2/postgres/src/backend/parser/analyze.c
src/k2/postgres/src/backend/parser/gram.y
src/k2/postgres/src/backend/parser/parse_clause.c
src/k2/postgres/src/backend/parser/parse_relation.c
src/k2/postgres/src/backend/parser/parse_utilcmd.c
src/k2/postgres/src/backend/postmaster/Makefile
src/k2/postgres/src/backend/postmaster/checkpointer.c
src/k2/postgres/src/backend/postmaster/pgstat.c
src/k2/postgres/src/backend/postmaster/postmaster.c
src/k2/postgres/src/backend/postmaster/postmaster_hook.c
src/k2/postgres/src/backend/rewrite/rewriteHandler.c
src/k2/postgres/src/backend/storage/buffer/bufmgr.c
src/k2/postgres/src/backend/storage/ipc/ipc.c
src/k2/postgres/src/backend/storage/ipc/procarray.c
src/k2/postgres/src/backend/storage/lmgr/lmgr.c
src/k2/postgres/src/backend/storage/lmgr/lock.c
src/k2/postgres/src/backend/storage/page/itemptr.c
src/k2/postgres/src/backend/tcop/postgres.c
src/k2/postgres/src/backend/tcop/pquery.c
src/k2/postgres/src/backend/tcop/utility.c
src/k2/postgres/src/backend/utils/adt/ri_triggers.c
src/k2/postgres/src/backend/utils/adt/selfuncs.c
src/k2/postgres/src/backend/utils/cache/catcache.c
src/k2/postgres/src/backend/utils/cache/evtcache.c
src/k2/postgres/src/backend/utils/cache/lsyscache.c
src/k2/postgres/src/backend/utils/cache/plancache.c
src/k2/postgres/src/backend/utils/cache/relcache.c
src/k2/postgres/src/backend/utils/cache/syscache.c
src/k2/postgres/src/backend/utils/cache/typcache.c
src/k2/postgres/src/backend/utils/error/elog.c
src/k2/postgres/src/backend/utils/fmgr/fmgr.c
src/k2/postgres/src/backend/utils/init/miscinit.c
src/k2/postgres/src/backend/utils/init/postinit.c
src/k2/postgres/src/backend/utils/misc/Makefile
src/k2/postgres/src/backend/utils/misc/guc.c
src/k2/postgres/src/backend/utils/misc/pg_k2pg_utils.c
src/k2/postgres/src/backend/utils/mmgr/mcxt.c
src/k2/postgres/src/backend/utils/resowner/resowner.c
src/k2/postgres/src/backend/utils/sort/tuplesort.c
src/k2/postgres/src/backend/utils/time/snapmgr.c
src/k2/postgres/src/backend/ybgate/Makefile
src/k2/postgres/src/backend/ybgate/ybgate_api.c
src/k2/postgres/src/bin/initdb/Makefile
src/k2/postgres/src/bin/initdb/initdb.c
src/k2/postgres/src/bin/pg_dump/Makefile
src/k2/postgres/src/bin/pg_dump/pg_backup.h
src/k2/postgres/src/bin/pg_dump/pg_dump.c
src/k2/postgres/src/bin/pg_dump/pg_dumpall.c
src/k2/postgres/src/bin/pg_waldump/brindesc.c
src/k2/postgres/src/bin/pg_waldump/clogdesc.c
src/k2/postgres/src/bin/pg_waldump/committsdesc.c
src/k2/postgres/src/bin/pg_waldump/dbasedesc.c
src/k2/postgres/src/bin/pg_waldump/genericdesc.c
src/k2/postgres/src/bin/pg_waldump/gindesc.c
src/k2/postgres/src/bin/pg_waldump/gistdesc.c
src/k2/postgres/src/bin/pg_waldump/hashdesc.c
src/k2/postgres/src/bin/pg_waldump/heapdesc.c
src/k2/postgres/src/bin/pg_waldump/logicalmsgdesc.c
src/k2/postgres/src/bin/pg_waldump/mxactdesc.c
src/k2/postgres/src/bin/pg_waldump/nbtdesc.c
src/k2/postgres/src/bin/pg_waldump/relmapdesc.c
src/k2/postgres/src/bin/pg_waldump/replorigindesc.c
src/k2/postgres/src/bin/pg_waldump/seqdesc.c
src/k2/postgres/src/bin/pg_waldump/smgrdesc.c
src/k2/postgres/src/bin/pg_waldump/spgdesc.c
src/k2/postgres/src/bin/pg_waldump/standbydesc.c
src/k2/postgres/src/bin/pg_waldump/tblspcdesc.c
src/k2/postgres/src/bin/pg_waldump/xactdesc.c
src/k2/postgres/src/bin/pg_waldump/xlogdesc.c
src/k2/postgres/src/bin/pg_waldump/xlogreader.c
src/k2/postgres/src/bin/pgbench/pgbench.c
src/k2/postgres/src/bin/psql/help.c
src/k2/postgres/src/common/Makefile
src/k2/postgres/src/common/pg_k2pg_common.c
src/k2/postgres/src/common/username.c
src/k2/postgres/src/include/Makefile
src/k2/postgres/src/include/access/amapi.h
src/k2/postgres/src/include/access/genam.h
src/k2/postgres/src/include/access/htup.h
src/k2/postgres/src/include/access/itup.h
src/k2/postgres/src/include/access/relscan.h
src/k2/postgres/src/include/access/sysattr.h
src/k2/postgres/src/include/access/xact.h
src/k2/postgres/src/include/access/ybcam.h
src/k2/postgres/src/include/access/ybcin.h
src/k2/postgres/src/include/bootstrap/ybcbootstrap.h
src/k2/postgres/src/include/catalog/index.h
src/k2/postgres/src/include/catalog/ybctype.h
src/k2/postgres/src/include/commands/ybccmds.h
src/k2/postgres/src/include/common/pg_k2pg_common.h
src/k2/postgres/src/include/executor/executor.h
src/k2/postgres/src/include/executor/tuptable.h
src/k2/postgres/src/include/executor/ybcExpr.h
src/k2/postgres/src/include/executor/ybcModifyTable.h
src/k2/postgres/src/include/executor/ybc_fdw.h
src/k2/postgres/src/include/libpq/k2pg_pqcomm_extensions.h
src/k2/postgres/src/include/nodes/execnodes.h
src/k2/postgres/src/include/nodes/memnodes.h
src/k2/postgres/src/include/nodes/parsenodes.h
src/k2/postgres/src/include/optimizer/ybcplan.h
src/k2/postgres/src/include/pg_k2pg_utils.h
src/k2/postgres/src/include/pgstat.h
src/k2/postgres/src/include/postmaster/postmaster_hook.h
src/k2/postgres/src/include/utils/catcache.h
src/k2/postgres/src/include/utils/elog.h
src/k2/postgres/src/include/utils/memutils.h
src/k2/postgres/src/include/utils/palloc.h
src/k2/postgres/src/include/utils/relcache.h
src/k2/postgres/src/include/utils/resowner_private.h
src/k2/postgres/src/include/utils/syscache.h
src/k2/postgres/src/include/yb_overflow_utils.h
src/k2/postgres/src/include/ybgate/ybgate_api.h
src/k2/postgres/src/interfaces/libpq/fe-connect.c
src/k2/postgres/src/pl/plpgsql/src/pl_comp.c
src/k2/postgres/src/pl/plpgsql/src/pl_exec.c
src/k2/postgres/src/pl/plpgsql/src/pl_gram.y
src/k2/postgres/src/pl/plpgsql/src/plpgsql.h
src/k2/postgres/src/test/regress/GNUmakefile
src/k2/postgres/src/test/regress/chogori_schedule
src/k2/postgres/src/test/regress/expected/yb_bit.out
src/k2/postgres/src/test/regress/expected/yb_char.out
src/k2/postgres/src/test/regress/expected/yb_create_table.out
src/k2/postgres/src/test/regress/expected/yb_create_table_55k_secondary_index.out
src/k2/postgres/src/test/regress/expected/yb_create_type.out
src/k2/postgres/src/test/regress/expected/yb_disabled.out
src/k2/postgres/src/test/regress/expected/yb_dml_single_row.out
src/k2/postgres/src/test/regress/expected/yb_drop_table.out
src/k2/postgres/src/test/regress/expected/yb_feature_alter_rename.out
src/k2/postgres/src/test/regress/expected/yb_feature_colocation.out
src/k2/postgres/src/test/regress/expected/yb_feature_config.out
src/k2/postgres/src/test/regress/expected/yb_feature_copy.out
src/k2/postgres/src/test/regress/expected/yb_feature_db.out
src/k2/postgres/src/test/regress/expected/yb_feature_delete.out
src/k2/postgres/src/test/regress/expected/yb_feature_insert.out
src/k2/postgres/src/test/regress/expected/yb_feature_select.out
src/k2/postgres/src/test/regress/expected/yb_feature_types.out
src/k2/postgres/src/test/regress/expected/yb_feature_update.out
src/k2/postgres/src/test/regress/expected/yb_foreign_key.out
src/k2/postgres/src/test/regress/expected/yb_index_including.out
src/k2/postgres/src/test/regress/expected/yb_insert_conflict.out
src/k2/postgres/src/test/regress/expected/yb_interval.out
src/k2/postgres/src/test/regress/expected/yb_numeric.out
src/k2/postgres/src/test/regress/expected/yb_perf_secondary_index_scan.out
src/k2/postgres/src/test/regress/expected/yb_pg_aggregates.out
src/k2/postgres/src/test/regress/expected/yb_pg_alter_operator.out
src/k2/postgres/src/test/regress/expected/yb_pg_create_function_3.out
src/k2/postgres/src/test/regress/expected/yb_pg_create_table.out
src/k2/postgres/src/test/regress/expected/yb_pg_foreign_key.out
src/k2/postgres/src/test/regress/expected/yb_pg_insert.out
src/k2/postgres/src/test/regress/expected/yb_pg_plpgsql.out
src/k2/postgres/src/test/regress/expected/yb_pg_privileges.out
src/k2/postgres/src/test/regress/expected/yb_pg_rowsecurity.out
src/k2/postgres/src/test/regress/expected/yb_pg_rules.out
src/k2/postgres/src/test/regress/expected/yb_pg_triggers.out
src/k2/postgres/src/test/regress/expected/yb_pg_window.out
src/k2/postgres/src/test/regress/expected/yb_plpgsql.out
src/k2/postgres/src/test/regress/expected/yb_rolenames.out
src/k2/postgres/src/test/regress/expected/yb_sequence.out
src/k2/postgres/src/test/regress/output/yb_pg_create_function_2.source
src/k2/postgres/src/test/regress/pg_regress.c
src/k2/postgres/src/test/regress/sql/yb_bit.sql
src/k2/postgres/src/test/regress/sql/yb_create_table.sql
src/k2/postgres/src/test/regress/sql/yb_create_table_55k_secondary_index.sql
src/k2/postgres/src/test/regress/sql/yb_dml_single_row.sql
src/k2/postgres/src/test/regress/sql/yb_drop_table.sql
src/k2/postgres/src/test/regress/sql/yb_feature_colocation.sql
src/k2/postgres/src/test/regress/sql/yb_feature_config.sql
src/k2/postgres/src/test/regress/sql/yb_feature_copy.sql
src/k2/postgres/src/test/regress/sql/yb_feature_delete.sql
src/k2/postgres/src/test/regress/sql/yb_feature_insert.sql
src/k2/postgres/src/test/regress/sql/yb_feature_select.sql
src/k2/postgres/src/test/regress/sql/yb_feature_types.sql
src/k2/postgres/src/test/regress/sql/yb_feature_update.sql
src/k2/postgres/src/test/regress/sql/yb_foreign_key.sql
src/k2/postgres/src/test/regress/sql/yb_index_including.sql
src/k2/postgres/src/test/regress/sql/yb_interval.sql
src/k2/postgres/src/test/regress/sql/yb_numeric.sql
src/k2/postgres/src/test/regress/sql/yb_perf_secondary_index_scan.sql
src/k2/postgres/src/test/regress/sql/yb_pg_aggregates.sql
src/k2/postgres/src/test/regress/sql/yb_pg_alter_operator.sql
src/k2/postgres/src/test/regress/sql/yb_pg_foreign_key.sql
src/k2/postgres/src/test/regress/sql/yb_pg_window.sql
test/integration/README.md
test/integration/aggregate.py
test/integration/compoundkey.py
test/integration/database.py
test/integration/ddl.py
test/integration/dmlbasic.py
test/integration/helper.py
test/integration/index.py
test/integration/integrate.py
test/integration/integrate.sh
test/integration/isolation.py
test/integration/join.py
test/regression.sh