### PR TITLE
update HandleRangeConditions() in k2_adapter to handle multiple conditions for the same column

### DIFF
--- a/src/k2/connector/pggate/pg_gate_typedefs.h
+++ b/src/k2/connector/pggate/pg_gate_typedefs.h
@@ -183,7 +183,7 @@ typedef struct PgExecParameters {
   //     for filtering before LIMIT is applied.
   //   o ORDER BY clause is not processed by K2 platform. Similarly all rows must be fetched and sent
   //     to Postgres code layer.
-  uint64_t limit_count;
+  int64_t limit_count;
   uint64_t limit_offset;
   bool limit_use_default;
   // For now we only support one rowmark.


### PR DESCRIPTION
fixed the regression tests for yb_select. The root cause was that the same column could have multiple conditions, which was not handled correctly in HandleRangeConditions().

After the fix, yb_select passed. TPCC, integration, and regression tests passed.